### PR TITLE
feat(notifications): alertes métiers par email - temps réel météo/urgent + résumé quotidien

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,15 @@ SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=
 
+# Notifications métier par email (résumé quotidien + alertes temps réel)
+# Les alertes sont activées par défaut dès que SMTP_HOST/SMTP_USER sont définis.
+# NOTIF_ENABLED=false coupe tout (météo temps réel, urgent, résumé).
+NOTIF_ENABLED=true
+# Heure du résumé quotidien « Quoi faire ce matin ? » (heure locale conteneur, TZ).
+NOTIF_RESUME_HEURE=07:00
+# Fréquence (minutes) du scan météo temps réel + alertes urgentes (borné 5-1440).
+NOTIF_METEO_INTERVAL_MIN=30
+
 # Ollama Cloud (assistant chat — optionnel, désactivé par défaut côté public)
 OLLAMA_API_KEY=
 OLLAMA_MODEL=nemotron-3-nano:30b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,10 @@ services:
       SMTP_PASS: ${SMTP_PASS:-}
       SMTP_FROM: ${SMTP_FROM:-}
       FEEDBACK_EMAIL: ${FEEDBACK_EMAIL:-}
+      # Notifications métier par email (cron interne : résumé + alertes temps réel)
+      NOTIF_ENABLED: ${NOTIF_ENABLED:-true}
+      NOTIF_RESUME_HEURE: ${NOTIF_RESUME_HEURE:-07:00}
+      NOTIF_METEO_INTERVAL_MIN: ${NOTIF_METEO_INTERVAL_MIN:-30}
       # Audit compta 2026-06 : les bornes d'exercice comptable sont calculées
       # en heure locale du serveur — en UTC, une vente saisie le 1er janvier
       # 00h30 (heure de Paris) tombait dans l'exercice précédent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "mathjs": "^15.2.0",
         "next": "^16.2.10",
         "next-auth": "^5.0.0-beta.31",
+        "node-cron": "^4.6.0",
         "nodemailer": "^9.0.3",
         "ollama": "^0.6.3",
         "pdfkit": "^0.18.0",
@@ -7926,6 +7927,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/nodemailer": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mathjs": "^15.2.0",
     "next": "^16.2.10",
     "next-auth": "^5.0.0-beta.31",
+    "node-cron": "^4.6.0",
     "nodemailer": "^9.0.3",
     "ollama": "^0.6.3",
     "pdfkit": "^0.18.0",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,21 @@
+/**
+ * Hameçon de démarrage serveur Next.js (instrumentation, stable depuis
+ * Next 15). `register()` est appelé une fois à l'init du serveur Node —
+ * c'est le point d'attache durable du cron de notifications : il survit
+ * aux redémarrages (re-registré à chaque boot) et ne dépend d'aucune
+ * requête entrante.
+ *
+ * Le module est importé dynamiquement et tout est encapsulé en try/catch :
+ * un problème de scheduler ne doit jamais empêcher le serveur de démarrer.
+ */
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return
+
+  try {
+    const { initNotifScheduler } = await import("@/lib/notifications/scheduler")
+    initNotifScheduler()
+  } catch (error) {
+    console.error("[notifications] Échec d'initialisation du scheduler:", error)
+  }
+}

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -4,6 +4,15 @@
 
 import nodemailer from "nodemailer"
 
+/**
+ * URL publique de l'instance (dérivée de NEXTAUTH_URL, bascule propre en
+ * auto-hébergement). Utilisée pour les liens d'activation / reset de mot de
+ * passe. Sans NEXTAUTH_URL, on retombe sur l'hôte public historique.
+ */
+const APP_URL = (process.env.NEXTAUTH_URL || "https://gleba.fr").replace(/\/$/, "")
+
+export { APP_URL }
+
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: Number(process.env.SMTP_PORT) || 587,
@@ -118,7 +127,7 @@ export function newUserNotificationEmail(user: { email: string; name?: string | 
 
 export function verifyEmailEmail(name: string | null, token: string) {
   const displayName = name || "nouveau membre"
-  const verifyUrl = `https://gleba.fr/api/auth/verify?token=${token}`
+  const verifyUrl = `${APP_URL}/api/auth/verify?token=${token}`
   return {
     subject: "Gleba — Confirmez votre adresse email",
     html: `<!DOCTYPE html>
@@ -291,7 +300,7 @@ export function commandeBoutiqueEmail(args: CommandeBoutiqueEmailArgs) {
 
 export function passwordResetEmail(name: string | null, token: string) {
   const displayName = name || "utilisateur"
-  const resetUrl = `https://gleba.fr/reset-password?token=${token}`
+  const resetUrl = `${APP_URL}/reset-password?token=${token}`
   return {
     subject: "Gleba — Réinitialisation de votre mot de passe",
     html: `<!DOCTYPE html>

--- a/src/lib/notifications/config.ts
+++ b/src/lib/notifications/config.ts
@@ -1,0 +1,33 @@
+/**
+ * Configuration du scheduler de notifications — PUR, sans aucune dépendance
+ * runtime (testable directement, contrairement à scheduler.ts qui tire
+ * nodemailer/prisma via sender.ts).
+ */
+
+/** Parse « HH:MM » → { hour, minute } ou null si invalide. */
+export function parseHeureResume(value: string | undefined): { hour: number; minute: number } | null {
+  if (!value) return null
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim())
+  if (!match) return null
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (hour > 23 || minute > 59) return null
+  return { hour, minute }
+}
+
+/** Expression cron du résumé quotidien (défaut 07:00). */
+export function getResumeCronExpression(
+  env: Record<string, string | undefined> = process.env
+): string {
+  const heure = parseHeureResume(env.NOTIF_RESUME_HEURE) ?? { hour: 7, minute: 0 }
+  return `${heure.minute} ${heure.hour} * * *`
+}
+
+/** Intervalle (minutes) du scan météo — défaut 30, borné [5, 1440]. */
+export function getMeteoIntervalMinutes(
+  env: Record<string, string | undefined> = process.env
+): number {
+  const raw = Number.parseInt(env.NOTIF_METEO_INTERVAL_MIN ?? "30", 10)
+  if (!Number.isInteger(raw)) return 30
+  return Math.min(Math.max(raw, 5), 1440)
+}

--- a/src/lib/notifications/detect.test.ts
+++ b/src/lib/notifications/detect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+import { deciderIrrigationInutile, detecterAlertesMeteo } from "./detect"
+import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
+
+function jour(overrides: Partial<MeteoPrevision> & { date: string }): MeteoPrevision {
+  return {
+    tempMin: 10,
+    tempMax: 20,
+    tempMoy: 15,
+    precipitation: 0,
+    precipitationProba: 0,
+    et0: 2,
+    radiation: 20,
+    sunshine: 6,
+    humidityMin: 50,
+    humidityMax: 80,
+    windSpeedMax: 10,
+    ...overrides,
+  }
+}
+
+describe("detecterAlertesMeteo", () => {
+  it("signale un gel (tempMin <= 0), danger si sévère", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", tempMin: -2 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("gel")
+    expect(alertes[0].niveau).toBe("attention")
+    expect(alertes[0].key).toBe("gel:2026-08-10")
+
+    const severes = detecterAlertesMeteo([jour({ date: "2026-08-11", tempMin: -4 })])
+    expect(severes[0].niveau).toBe("danger")
+  })
+
+  it("signale une canicule (tempMax >= 35), danger si >= 40", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", tempMax: 36 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("canicule")
+    expect(alertes[0].niveau).toBe("attention")
+
+    const severes = detecterAlertesMeteo([jour({ date: "2026-08-11", tempMax: 41 })])
+    expect(severes[0].niveau).toBe("danger")
+  })
+
+  it("signale un vent fort (>= 50 km/h)", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", windSpeedMax: 55 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("vent")
+  })
+
+  it("ne signale pas un vent modéré (ex. 25 km/h)", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", windSpeedMax: 25 })])
+    expect(alertes).toHaveLength(0)
+  })
+
+  it("signale une pluie abondante (>= 20 mm)", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", precipitation: 22 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("pluie")
+    expect(alertes[0].niveau).toBe("attention")
+  })
+
+  it("signale un orage à partir du code WMO courant (95/96/99)", () => {
+    const orage: MeteoActuelle = {
+      temperature: 22,
+      humidity: 80,
+      windSpeed: 15,
+      windDirection: 200,
+      precipitation: 2,
+      weatherCode: 95,
+      weatherDescription: "Orage",
+    }
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10" })], orage)
+    expect(alertes.some((a) => a.type === "orage")).toBe(true)
+    expect(alertes.find((a) => a.type === "orage")?.niveau).toBe("attention")
+
+    const grele: MeteoActuelle = { ...orage, weatherCode: 99, weatherDescription: "Orage avec grêle forte" }
+    const avecGrele = detecterAlertesMeteo([jour({ date: "2026-08-10" })], grele)
+    expect(avecGrele.find((a) => a.type === "orage")?.niveau).toBe("danger")
+  })
+
+  it("n'émet aucune alerte par beau temps", () => {
+    const alertes = detecterAlertesMeteo([
+      jour({ date: "2026-08-10", tempMin: 12, tempMax: 24, windSpeedMax: 15, precipitation: 2 }),
+    ])
+    expect(alertes).toHaveLength(0)
+  })
+
+  it("respecte l'horizon demandé (pas d'alerte au-delà)", () => {
+    const previsions = [
+      jour({ date: "2026-08-10", tempMax: 20 }),
+      jour({ date: "2026-08-11", tempMax: 38 }),
+      jour({ date: "2026-08-12", tempMax: 38 }),
+    ]
+    const alertes = detecterAlertesMeteo(previsions, null, { horizonJours: 2 })
+    expect(alertes.filter((a) => a.type === "canicule")).toHaveLength(1)
+    expect(alertes[0].date).toBe("2026-08-11")
+  })
+})
+
+describe("deciderIrrigationInutile", () => {
+  it("inutile si >= 5 mm de pluie prévus le jour J", () => {
+    expect(deciderIrrigationInutile({ pluiePrevue: 6, pluieRecente3j: 0, joursAvant: 0 })).toBe(true)
+  })
+
+  it("inutile si pluie récente >= 5 mm et échéance dans les 3 jours", () => {
+    expect(deciderIrrigationInutile({ pluiePrevue: null, pluieRecente3j: 12, joursAvant: 1 })).toBe(true)
+    // Échéance plus lointaine → la pluie récente ne couvre plus
+    expect(deciderIrrigationInutile({ pluiePrevue: null, pluieRecente3j: 12, joursAvant: 5 })).toBe(false)
+  })
+
+  it("nécessaire si ni pluie prévue ni pluie récente", () => {
+    expect(deciderIrrigationInutile({ pluiePrevue: 1, pluieRecente3j: 2, joursAvant: 0 })).toBe(false)
+    expect(deciderIrrigationInutile({ pluiePrevue: null, pluieRecente3j: 0, joursAvant: 0 })).toBe(false)
+  })
+})

--- a/src/lib/notifications/detect.test.ts
+++ b/src/lib/notifications/detect.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { deciderIrrigationInutile, detecterAlertesMeteo } from "./detect"
+import {
+  deciderIrrigationInutile,
+  detecterAlertesMeteo,
+  formaterTemporaliteAlerte,
+  indicationHoraireAlerte,
+} from "./detect"
 import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
 
 function jour(overrides: Partial<MeteoPrevision> & { date: string }): MeteoPrevision {
@@ -94,6 +99,37 @@ describe("detecterAlertesMeteo", () => {
     const alertes = detecterAlertesMeteo(previsions, null, { horizonJours: 2 })
     expect(alertes.filter((a) => a.type === "canicule")).toHaveLength(1)
     expect(alertes[0].date).toBe("2026-08-11")
+  })
+})
+
+describe("formaterTemporaliteAlerte", () => {
+  // Jeudi 13 août 2026 — référence fixe pour des tests déterministes.
+  const reference = new Date(2026, 7, 13)
+
+  it("indique « Aujourd'hui » avec le jour et la date en français", () => {
+    expect(formaterTemporaliteAlerte("2026-08-13", reference)).toBe("Aujourd'hui (jeudi 13 août)")
+  })
+
+  it("indique « Demain » pour le lendemain", () => {
+    expect(formaterTemporaliteAlerte("2026-08-14", reference)).toBe("Demain (vendredi 14 août)")
+  })
+
+  it("indique « le <jour> » au-delà de J+1", () => {
+    expect(formaterTemporaliteAlerte("2026-08-15", reference)).toBe("le samedi 15 août")
+  })
+
+  it("retourne la date brute si le format est invalide", () => {
+    expect(formaterTemporaliteAlerte("invalide", reference)).toBe("invalide")
+  })
+})
+
+describe("indicationHoraireAlerte", () => {
+  it("fournit une indication de moment pour chaque type d'alerte", () => {
+    expect(indicationHoraireAlerte("gel")).toMatch(/fin de nuit/)
+    expect(indicationHoraireAlerte("canicule")).toMatch(/début d'après-midi/)
+    expect(indicationHoraireAlerte("vent")).toMatch(/l'après-midi/)
+    expect(indicationHoraireAlerte("pluie")).toMatch(/journée/)
+    expect(indicationHoraireAlerte("orage")).toMatch(/proximité immédiate/)
   })
 })
 

--- a/src/lib/notifications/detect.ts
+++ b/src/lib/notifications/detect.ts
@@ -1,0 +1,176 @@
+/**
+ * Détection PURE des conditions à risque (météo + irrigation).
+ *
+ * Consomme les données déjà fetchées par `@/lib/meteo` (fetchOpenMeteoForecast,
+ * fetchOpenMeteoHistory) — aucune duplication des appels API ici.
+ *
+ * Seuils calibrés pour des NOTIFICATIONS par email (donc volontairement plus
+ * exigeants que les alertes in-app de `meteo-agro.genererAlertesMeteo` :
+ * un email pour 19 km/h de vent serait du spam) :
+ *   - gel         : tempMin <= 0 °C
+ *   - canicule    : tempMax >= 35 °C
+ *   - vent fort   : windSpeedMax >= 50 km/h
+ *   - pluie abondante : precipitation >= 20 mm/jour
+ *   - orage       : code WMO courant 95/96/99 (orage, grêle)
+ */
+
+import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
+import type { AlerteMeteoNotification } from "./types"
+
+export const SEUILS_METEO = {
+  gel: { tempMin: 0, danger: -3 },
+  canicule: { tempMax: 35, danger: 40 },
+  ventFort: { vitesse: 50, danger: 70 },
+  pluieAbondante: { mm: 20, danger: 40 },
+  codesOrage: [95, 96, 99] as readonly number[],
+} as const
+
+/** Code WMO d'un orage avec grêle (danger). */
+const CODES_GRÊLE = [96, 99]
+
+function todayIso(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+    now.getDate()
+  ).padStart(2, "0")}`
+}
+
+/**
+ * Détecte les alertes météo notifiables sur l'horizon demandé (défaut : tous
+ * les jours de la prévision). En temps réel on limite à 48 h ; le résumé du
+ * matin utilise la journée courante.
+ */
+export function detecterAlertesMeteo(
+  previsions: MeteoPrevision[],
+  current: MeteoActuelle | null = null,
+  options: { horizonJours?: number } = {}
+): AlerteMeteoNotification[] {
+  const horizon = options.horizonJours ?? previsions.length
+  const alertes: AlerteMeteoNotification[] = []
+
+  for (let i = 0; i < Math.min(horizon, previsions.length); i++) {
+    const jour = previsions[i]
+    if (!jour) continue
+
+    // ── Gel ──
+    if (jour.tempMin <= SEUILS_METEO.gel.tempMin) {
+      alertes.push({
+        type: "gel",
+        date: jour.date,
+        niveau: jour.tempMin <= SEUILS_METEO.gel.danger ? "danger" : "attention",
+        message: `Risque de gel : ${jour.tempMin}°C prévu`,
+        details:
+          jour.tempMin <= SEUILS_METEO.gel.danger
+            ? "Gel sévère annoncé. Protéger les cultures sensibles (voile d'hivernage, paillage, tunnel). Risque fort pour les semis récents et les arbres en floraison."
+            : "Gel léger possible. Surveiller les cultures non protégées et les semis récents ; un voile de protection peut suffire.",
+        key: `gel:${jour.date}`,
+      })
+    }
+
+    // ── Canicule ──
+    if (jour.tempMax >= SEUILS_METEO.canicule.tempMax) {
+      alertes.push({
+        type: "canicule",
+        date: jour.date,
+        niveau: jour.tempMax >= SEUILS_METEO.canicule.danger ? "danger" : "attention",
+        message: `Canicule : ${jour.tempMax}°C prévu`,
+        details:
+          "Augmenter la fréquence d'irrigation, ombrer les cultures sensibles (salades, épinards). Arroser tôt le matin ou le soir pour limiter l'évaporation.",
+        key: `canicule:${jour.date}`,
+      })
+    }
+
+    // ── Vent fort ──
+    if (jour.windSpeedMax >= SEUILS_METEO.ventFort.vitesse) {
+      alertes.push({
+        type: "vent",
+        date: jour.date,
+        niveau: jour.windSpeedMax >= SEUILS_METEO.ventFort.danger ? "danger" : "attention",
+        message: `Vent fort : ${Math.round(jour.windSpeedMax)} km/h attendu`,
+        details:
+          "Éviter tout traitement phytosanitaire (interdit au-delà de 19 km/h). Brise-vent et tuteurage à vérifier ; reporter les semis en plein vent si possible.",
+        key: `vent:${jour.date}`,
+      })
+    }
+
+    // ── Pluie abondante ──
+    if (jour.precipitation >= SEUILS_METEO.pluieAbondante.mm) {
+      alertes.push({
+        type: "pluie",
+        date: jour.date,
+        niveau: jour.precipitation >= SEUILS_METEO.pluieAbondante.danger ? "danger" : "attention",
+        message: `Pluie abondante : ${jour.precipitation} mm prévus`,
+        details:
+          "Reporter les semis et plantations si possible ; surveiller l'engorgement des planches et la sensibilité des jeunes plants. L'irrigation des prochains jours sera probablement inutile.",
+        key: `pluie:${jour.date}`,
+      })
+    }
+  }
+
+  // ── Orage (conditions actuelles, code WMO) ──
+  if (current && SEUILS_METEO.codesOrage.includes(current.weatherCode)) {
+    const avecGrêle = CODES_GRÊLE.includes(current.weatherCode)
+    alertes.push({
+      type: "orage",
+      date: todayIso(),
+      niveau: avecGrêle ? "danger" : "attention",
+      message: `Orage${avecGrêle ? " avec grêle" : ""} en cours : ${current.weatherDescription}`,
+      details: avecGrêle
+        ? "Risque de grêle : mettre à l'abri les plants les plus précieux, fermer les tunnels. Débrancher les équipements électriques sensibles."
+        : "Orage à proximité : couvrir les semis sensibles si possible ; rester attentif aux rafales.",
+      key: `orage:${todayIso()}`,
+    })
+  }
+
+  return alertes
+}
+
+export const SEUILS_IRRIGATION_INUTILE = {
+  pluiePrevue: 5, // mm prévus le jour J → irrigation inutile
+  pluieRecente: 5, // mm cumulés sur 3 j
+  joursCouverture: 3,
+} as const
+
+/**
+ * Décide si une irrigation planifiée est probablement inutile (même heuristique
+ * que la route /api/calendrier, factorisée pour être testable et réutilisée
+ * par les alertes temps réel).
+ */
+export function deciderIrrigationInutile(opts: {
+  pluiePrevue: number | null
+  pluieRecente3j: number
+  joursAvant: number
+}): boolean {
+  const { pluiePrevue, pluieRecente3j, joursAvant } = opts
+  const inutileParPluieRecente =
+    pluieRecente3j >= SEUILS_IRRIGATION_INUTILE.pluieRecente &&
+    joursAvant <= SEUILS_IRRIGATION_INUTILE.joursCouverture
+  const inutileParPrevision =
+    pluiePrevue !== null && pluiePrevue >= SEUILS_IRRIGATION_INUTILE.pluiePrevue
+  return inutileParPluieRecente || inutileParPrevision
+}
+
+/** Date locale du serveur (fuseau TZ, ex. Europe/Paris) au format YYYY-MM-DD. */
+export function dateLocaleIso(date: Date = new Date()): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+/** Début de journée locale (minuit) sous forme de Date. */
+export function debutDeJournee(date: Date = new Date()): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+/** Fin de journée locale (minuit + 1 jour). */
+export function finDeJournee(date: Date = new Date()): Date {
+  const start = debutDeJournee(date)
+  return new Date(start.getFullYear(), start.getMonth(), start.getDate() + 1)
+}
+
+export function formatDateFr(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number)
+  if (!y || !m || !d) return iso
+  return `${String(d).padStart(2, "0")}/${String(m).padStart(2, "0")}/${y}`
+}

--- a/src/lib/notifications/detect.ts
+++ b/src/lib/notifications/detect.ts
@@ -15,7 +15,7 @@
  */
 
 import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
-import type { AlerteMeteoNotification } from "./types"
+import type { AlerteMeteoNotification, TypeAlerteMeteo } from "./types"
 
 export const SEUILS_METEO = {
   gel: { tempMin: 0, danger: -3 },
@@ -173,4 +173,47 @@ export function formatDateFr(iso: string): string {
   const [y, m, d] = iso.split("-").map(Number)
   if (!y || !m || !d) return iso
   return `${String(d).padStart(2, "0")}/${String(m).padStart(2, "0")}/${y}`
+}
+
+/** Jour de la semaine + date en français (ex. « jeudi 13 août »). */
+const FORMATTEUR_DATE_LONGUE = new Intl.DateTimeFormat("fr-FR", {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+})
+
+/**
+ * Temporalité lisible d'une alerte météo pour le corps de l'email :
+ *   - « Aujourd'hui (jeudi 13 août) » si la date est le jour courant,
+ *   - « Demain (vendredi 14 août) » si c'est le lendemain,
+ *   - « le samedi 15 août » sinon.
+ * `reference` ne sert qu'aux tests (rend la fonction déterministe).
+ */
+export function formaterTemporaliteAlerte(dateIso: string, reference: Date = new Date()): string {
+  const [y, m, d] = dateIso.split("-").map(Number)
+  if (!y || !m || !d) return dateIso
+  const date = new Date(y, m - 1, d)
+  const diffJours = Math.round(
+    (debutDeJournee(date).getTime() - debutDeJournee(reference).getTime()) / 86400000
+  )
+  const label = FORMATTEUR_DATE_LONGUE.format(date)
+  if (diffJours === 0) return `Aujourd'hui (${label})`
+  if (diffJours === 1) return `Demain (${label})`
+  return `le ${label}`
+}
+
+/** Indication informative du moment de la journée concerné (petite ligne de l'email). */
+export function indicationHoraireAlerte(type: TypeAlerteMeteo): string {
+  switch (type) {
+    case "gel":
+      return "Risque de gel en fin de nuit / au lever du jour."
+    case "canicule":
+      return "Température maximale attendue en début d'après-midi."
+    case "vent":
+      return "Rafales les plus fortes attendues l'après-midi."
+    case "pluie":
+      return "Précipitations concentrées sur la journée."
+    case "orage":
+      return "Orage possible à proximité immédiate."
+  }
 }

--- a/src/lib/notifications/queries.ts
+++ b/src/lib/notifications/queries.ts
@@ -1,0 +1,498 @@
+/**
+ * Couche DONNÉES du système de notifications.
+ *
+ * Réutilise volontairement les fonctions existantes plutôt que de les
+ * dupliquer : fetchOpenMeteoForecast / fetchOpenMeteoHistory (lib/meteo),
+ * grouperIrrigationsPlanifieesParPlancheEtJour (lib/irrigation-planche),
+ * alertesAssociations (lib/associations-alertes).
+ */
+
+import prisma from "@/lib/prisma"
+import { fetchOpenMeteoForecast, fetchOpenMeteoHistory } from "@/lib/meteo"
+import { grouperIrrigationsPlanifieesParPlancheEtJour } from "@/lib/irrigation-planche"
+import { alertesAssociations } from "@/lib/associations-alertes"
+import {
+  dateLocaleIso,
+  debutDeJournee,
+  deciderIrrigationInutile,
+  detecterAlertesMeteo,
+  finDeJournee,
+  formatDateFr,
+} from "./detect"
+import type {
+  AlerteMeteoNotification,
+  AlerteUrgente,
+  DestinataireNotification,
+  TacheJour,
+} from "./types"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Destinataires
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EMAIL_VALIDE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * Tous les users actifs ayant un email valide — par défaut activés pour les
+ * notifications métier. `emailOptOut` (désabonnement existant de Gleba pour
+ * les emails non transactionnels) est respecté.
+ */
+export async function getDestinatairesNotifications(): Promise<DestinataireNotification[]> {
+  const users = await prisma.user.findMany({
+    where: { active: true, emailOptOut: false },
+    select: { id: true, email: true, name: true },
+  })
+  return users
+    .filter((user) => user.email && EMAIL_VALIDE.test(user.email))
+    .map((user) => ({ id: user.id, email: user.email as string, name: user.name }))
+}
+
+/** Coordonnées (lat/lng) dédupliquées des parcelles géoréférencées. */
+export async function getCoordsUtilisateur(
+  userId: string
+): Promise<Array<{ lat: number; lng: number }>> {
+  const parcelles = await prisma.parcelleGeo.findMany({
+    where: { userId, centroidLat: { not: null }, centroidLng: { not: null } },
+    select: { centroidLat: true, centroidLng: true },
+  })
+  const vus = new Set<string>()
+  const coords: Array<{ lat: number; lng: number }> = []
+  for (const parcelle of parcelles) {
+    const lat = parcelle.centroidLat
+    const lng = parcelle.centroidLng
+    if (lat === null || lng === null) continue
+    const cle = `${Math.round(lat * 100)}_${Math.round(lng * 100)}`
+    if (vus.has(cle)) continue
+    vus.add(cle)
+    coords.push({ lat, lng })
+  }
+  return coords
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Météo — agrégat prévisions + pluie récente (même approche que /api/calendrier)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MeteoParCoord {
+  precipParCoordEtJour: Map<string, Map<string, number>>
+  pluieRecente3jParCoord: Map<string, number>
+}
+
+function coordKey(lat: number, lng: number): string {
+  return `${Math.round(lat * 100)}_${Math.round(lng * 100)}`
+}
+
+/** Précipitations prévues par jour + pluie cumulée sur 3 j, par coordonnée. */
+export async function fetchMeteoParCoord(
+  coords: Array<{ lat: number; lng: number }>
+): Promise<MeteoParCoord> {
+  const precipParCoordEtJour = new Map<string, Map<string, number>>()
+  const pluieRecente3jParCoord = new Map<string, number>()
+
+  await Promise.all(
+    coords.map(async ({ lat, lng }) => {
+      const cle = coordKey(lat, lng)
+      try {
+        const forecast = await fetchOpenMeteoForecast(lat, lng)
+        const parJour = new Map<string, number>()
+        for (const jour of forecast.daily) parJour.set(jour.date, jour.precipitation)
+        precipParCoordEtJour.set(cle, parJour)
+
+        const today = new Date()
+        const j3 = new Date(today)
+        j3.setDate(j3.getDate() - 3)
+        const yesterday = new Date(today)
+        yesterday.setDate(yesterday.getDate() - 1)
+        const historique = await fetchOpenMeteoHistory(
+          lat,
+          lng,
+          j3.toISOString().split("T")[0],
+          yesterday.toISOString().split("T")[0]
+        )
+        const pluieHisto = historique.reduce((somme, jour) => somme + jour.precipitation, 0)
+        const pluieAujourdhui = forecast.daily[0]?.precipitation ?? 0
+        pluieRecente3jParCoord.set(cle, pluieHisto + pluieAujourdhui)
+      } catch (error) {
+        // Une coordonnée en erreur ne doit pas faire échouer le scan entier
+        console.warn(`[notifications] Météo indisponible pour ${cle}:`, error)
+      }
+    })
+  )
+
+  return { precipParCoordEtJour, pluieRecente3jParCoord }
+}
+
+/** Alertes météo notifiables du jour (horizon 24 h) pour un utilisateur. */
+export async function recupererAlertesMeteoJour(userId: string): Promise<AlerteMeteoNotification[]> {
+  const coords = await getCoordsUtilisateur(userId)
+  if (coords.length === 0) return []
+
+  const alertes: AlerteMeteoNotification[] = []
+  for (const { lat, lng } of coords) {
+    try {
+      const { current, daily } = await fetchOpenMeteoForecast(lat, lng)
+      alertes.push(...detecterAlertesMeteo(daily, current, { horizonJours: 1 }))
+    } catch (error) {
+      console.warn(`[notifications] Prévisions indisponibles pour ${coordKey(lat, lng)}:`, error)
+    }
+  }
+  return alertes
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Résumé quotidien — tâches du jour
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CULTURE_SELECT = {
+  id: true,
+  especeId: true,
+  varieteId: true,
+  dateSemis: true,
+  datePlantation: true,
+  dateRecolte: true,
+  semisFait: true,
+  plantationFaite: true,
+  recolteFaite: true,
+  espece: { select: { couleur: true, nom: true } },
+  variete: { select: { nom: true } },
+  planche: { select: { nom: true, ilot: true, parcelleGeo: { select: { centroidLat: true, centroidLng: true } } } },
+} as const
+
+interface CultureAvecPlanche {
+  id: number
+  especeId: string
+  varieteId: string | null
+  semisFait: boolean
+  plantationFaite: boolean
+  recolteFaite: boolean
+  espece: { couleur: string | null; nom: string | null } | null
+  variete: { nom: string | null } | null
+  planche: { nom: string | null; ilot: string | null } | null
+}
+
+function cultureVersTache(
+  culture: CultureAvecPlanche,
+  type: "semis" | "plantation" | "recolte",
+  date: Date
+): TacheJour {
+  const fait = type === "semis" ? culture.semisFait : type === "plantation" ? culture.plantationFaite : culture.recolteFaite
+  return {
+    id: culture.id,
+    type,
+    especeNom: culture.espece?.nom ?? culture.especeId,
+    varieteNom: culture.variete?.nom ?? culture.varieteId ?? null,
+    plancheName: culture.planche?.nom ?? null,
+    ilot: culture.planche?.ilot ?? null,
+    date: date.toISOString(),
+    fait,
+    couleur: culture.espece?.couleur ?? null,
+  }
+}
+
+/**
+ * Tâches planifiées aujourd'hui (semis, plantations, récoltes, irrigations
+ * regroupées par planche/jour via la fonction existante). Inclut la météo
+ * d'irrigation (pluie prévue, passage probablement inutile).
+ */
+export async function chargerTachesDuJour(userId: string): Promise<TacheJour[]> {
+  const start = debutDeJournee()
+  const end = finDeJournee()
+
+  const [semis, plantations, recoltes, irrigations, coords] = await Promise.all([
+    prisma.culture.findMany({
+      where: { userId, dateSemis: { gte: start, lte: end } },
+      select: CULTURE_SELECT,
+    }),
+    prisma.culture.findMany({
+      where: { userId, datePlantation: { gte: start, lte: end } },
+      select: CULTURE_SELECT,
+    }),
+    prisma.culture.findMany({
+      where: { userId, dateRecolte: { gte: start, lte: end } },
+      select: CULTURE_SELECT,
+    }),
+    prisma.irrigationPlanifiee.findMany({
+      where: { userId, datePrevue: { gte: start, lte: end } },
+      include: {
+        culture: {
+          select: {
+            id: true,
+            especeId: true,
+            varieteId: true,
+            espece: { select: { couleur: true, nom: true } },
+            variete: { select: { nom: true } },
+            planche: {
+              select: {
+                nom: true,
+                ilot: true,
+                parcelleGeo: { select: { centroidLat: true, centroidLng: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+    getCoordsUtilisateur(userId),
+  ])
+
+  const taches: TacheJour[] = [
+    ...semis.map((c) => cultureVersTache(c as CultureAvecPlanche, "semis", c.dateSemis as Date)),
+    ...plantations.map((c) =>
+      cultureVersTache(c as CultureAvecPlanche, "plantation", c.datePlantation as Date)
+    ),
+    ...recoltes.map((c) => cultureVersTache(c as CultureAvecPlanche, "recolte", c.dateRecolte as Date)),
+  ]
+
+  if (irrigations.length === 0) return taches
+
+  const meteo = await fetchMeteoParCoord(coords)
+  const fallback = coords[0]
+
+  const mappees = irrigations.map((irrigation) => {
+    const parcelle = irrigation.culture.planche?.parcelleGeo
+    const lat = parcelle?.centroidLat ?? fallback?.lat
+    const lng = parcelle?.centroidLng ?? fallback?.lng
+    let pluiePrevue: number | null = null
+    let probablementInutile = false
+    if (lat !== undefined && lng !== undefined) {
+      const dateStr = irrigation.datePrevue.toISOString().split("T")[0]
+      pluiePrevue = meteo.precipParCoordEtJour.get(coordKey(lat, lng))?.get(dateStr) ?? null
+      const pluieRecente = meteo.pluieRecente3jParCoord.get(coordKey(lat, lng)) ?? 0
+      const joursAvant = Math.floor((irrigation.datePrevue.getTime() - Date.now()) / 86_400_000)
+      probablementInutile = deciderIrrigationInutile({ pluiePrevue, pluieRecente3j: pluieRecente, joursAvant })
+    }
+    return {
+      id: irrigation.id,
+      type: "irrigation" as const,
+      especeId: irrigation.culture.especeId,
+      varieteId: irrigation.culture.varieteId || null,
+      plancheId: irrigation.culture.planche?.nom || null,
+      plancheName: irrigation.culture.planche?.nom || null,
+      ilot: irrigation.culture.planche?.ilot || null,
+      datePrevue: irrigation.datePrevue.toISOString(),
+      date: irrigation.datePrevue.toISOString(),
+      fait: irrigation.fait,
+      couleur: irrigation.culture.espece?.couleur || null,
+      especeNom: irrigation.culture.espece?.nom ?? irrigation.culture.especeId,
+      varieteNom: irrigation.culture.variete?.nom ?? irrigation.culture.varieteId ?? null,
+      cultureId: irrigation.culture.id,
+      retardJours: 0,
+      pluiePrevue: pluiePrevue !== null ? Math.round(pluiePrevue * 10) / 10 : null,
+      probablementInutile,
+    }
+  })
+
+  const groupes = grouperIrrigationsPlanifieesParPlancheEtJour(mappees)
+  for (const groupe of groupes) {
+    taches.push({
+      id: groupe.irrigationIds[0],
+      type: "irrigation",
+      especeNom: groupe.especeNom ?? "Irrigation",
+      varieteNom: null,
+      plancheName: groupe.plancheName ?? null,
+      ilot: groupe.ilot ?? null,
+      date: groupe.datePrevue,
+      fait: groupe.fait,
+      couleur: groupe.couleur ?? null,
+      pluiePrevue: groupe.pluiePrevue,
+      probablementInutile: groupe.probablementInutile,
+    })
+  }
+
+  return taches
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alertes urgentes (temps réel)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Irrigation(s) du jour probablement inutiles (pluie récente/prévue). */
+async function detecterIrrigationsInutiles(userId: string): Promise<AlerteUrgente[]> {
+  const start = debutDeJournee()
+  const end = finDeJournee()
+  const [irrigations, coords] = await Promise.all([
+    prisma.irrigationPlanifiee.findMany({
+      where: { userId, fait: false, datePrevue: { gte: start, lte: end } },
+      include: {
+        culture: {
+          select: {
+            id: true,
+            especeId: true,
+            varieteId: true,
+            espece: { select: { nom: true } },
+            variete: { select: { nom: true } },
+            planche: {
+              select: {
+                nom: true,
+                ilot: true,
+                parcelleGeo: { select: { centroidLat: true, centroidLng: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+    getCoordsUtilisateur(userId),
+  ])
+  if (irrigations.length === 0) return []
+
+  const meteo = await fetchMeteoParCoord(coords)
+  const fallback = coords[0]
+
+  const mappees = irrigations.map((irrigation) => {
+    const parcelle = irrigation.culture.planche?.parcelleGeo
+    const lat = parcelle?.centroidLat ?? fallback?.lat
+    const lng = parcelle?.centroidLng ?? fallback?.lng
+    let pluiePrevue: number | null = null
+    let probablementInutile = false
+    if (lat !== undefined && lng !== undefined) {
+      const dateStr = irrigation.datePrevue.toISOString().split("T")[0]
+      pluiePrevue = meteo.precipParCoordEtJour.get(coordKey(lat, lng))?.get(dateStr) ?? null
+      const pluieRecente = meteo.pluieRecente3jParCoord.get(coordKey(lat, lng)) ?? 0
+      const joursAvant = Math.floor((irrigation.datePrevue.getTime() - Date.now()) / 86_400_000)
+      probablementInutile = deciderIrrigationInutile({ pluiePrevue, pluieRecente3j: pluieRecente, joursAvant })
+    }
+    return {
+      id: irrigation.id,
+      type: "irrigation" as const,
+      especeId: irrigation.culture.especeId,
+      varieteId: irrigation.culture.varieteId || null,
+      plancheId: irrigation.culture.planche?.nom || null,
+      plancheName: irrigation.culture.planche?.nom || null,
+      ilot: irrigation.culture.planche?.ilot || null,
+      datePrevue: irrigation.datePrevue.toISOString(),
+      date: irrigation.datePrevue.toISOString(),
+      fait: irrigation.fait,
+      couleur: null,
+      especeNom: irrigation.culture.espece?.nom ?? irrigation.culture.especeId,
+      varieteNom: irrigation.culture.variete?.nom ?? irrigation.culture.varieteId ?? null,
+      cultureId: irrigation.culture.id,
+      retardJours: 0,
+      pluiePrevue: pluiePrevue !== null ? Math.round(pluiePrevue * 10) / 10 : null,
+      probablementInutile,
+    }
+  })
+
+  const groupes = grouperIrrigationsPlanifieesParPlancheEtJour(mappees)
+  const urgentes: AlerteUrgente[] = []
+  const dateStr = dateLocaleIso()
+  for (const groupe of groupes) {
+    if (!groupe.probablementInutile) continue
+    const planche = groupe.plancheName ?? "sans planche"
+    urgentes.push({
+      type: "irrigation-inutile",
+      titre: `irrigation planche ${planche}`,
+      message: groupe.especeNom
+        ? `L'irrigation prévue aujourd'hui pour « ${groupe.especeNom} » (planche ${planche}) est probablement inutile : ${
+            groupe.pluiePrevue != null && groupe.pluiePrevue >= 5
+              ? `${groupe.pluiePrevue} mm de pluie sont prévus.`
+              : "les précipitations récentes couvrent le besoin en eau."
+          }`
+        : `Irrigation planche ${planche} probablement inutile : pluie suffisante.`,
+      key: `irrigation-inutile:${groupe.plancheId ?? groupe.cultureIds[0]}:${dateStr}`,
+    })
+  }
+  return urgentes
+}
+
+/** Associations défavorables (incompatibles) sur les planches actives. */
+async function detecterAssociationsIncompatibles(userId: string): Promise<AlerteUrgente[]> {
+  const planches = await prisma.planche.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      nom: true,
+      cultures: {
+        // Cultures « en place » : pas encore récoltées, cycle non terminé.
+        where: { recolteFaite: false, terminee: null },
+        select: { especeId: true },
+      },
+    },
+  })
+
+  const urgentes: AlerteUrgente[] = []
+  for (const planche of planches) {
+    const especesIds = planche.cultures.map((c) => c.especeId).filter(Boolean) as string[]
+    if (especesIds.length < 2) continue
+    let alertes
+    try {
+      alertes = await alertesAssociations(prisma, especesIds)
+    } catch (error) {
+      console.warn(`[notifications] alertesAssociations planche ${planche.id} en échec:`, error)
+      continue
+    }
+    for (const alerte of alertes) {
+      if (alerte.type !== "defavorable") continue
+      const [a, b] = alerte.especes
+      urgentes.push({
+        type: "association-incompatible",
+        titre: `association incompatible planche ${planche.nom}`,
+        message: alerte.message,
+        key: `association-incompatible:${planche.id}:${[a, b].sort().join("-")}`,
+      })
+    }
+  }
+  return urgentes
+}
+
+/** Tâches (semis/plantation/récolte) dont l'échéance est dépassée et non faites. */
+async function detecterTachesEnRetard(userId: string): Promise<AlerteUrgente[]> {
+  const start = debutDeJournee()
+  const cultures = await prisma.culture.findMany({
+    where: {
+      userId,
+      semisFait: false,
+      plantationFaite: false,
+      recolteFaite: false,
+      terminee: null,
+      OR: [
+        { dateSemis: { not: null, lt: start } },
+        { datePlantation: { not: null, lt: start } },
+        { dateRecolte: { not: null, lt: start } },
+      ],
+    },
+    select: {
+      id: true,
+      especeId: true,
+      dateSemis: true,
+      datePlantation: true,
+      dateRecolte: true,
+      espece: { select: { nom: true } },
+      planche: { select: { nom: true } },
+    },
+  })
+
+  const urgentes: AlerteUrgente[] = []
+  for (const culture of cultures) {
+    const actions: Array<{ kind: "semis" | "plantation" | "recolte"; date: Date }> = []
+    if (culture.dateSemis) actions.push({ kind: "semis", date: culture.dateSemis })
+    if (culture.datePlantation) actions.push({ kind: "plantation", date: culture.datePlantation })
+    if (culture.dateRecolte) actions.push({ kind: "recolte", date: culture.dateRecolte })
+    const enRetard = actions.filter((a) => a.date < start).sort((a, b) => a.date.getTime() - b.date.getTime())
+    if (enRetard.length === 0) continue
+
+    const { kind, date } = enRetard[0]
+    const jours = Math.max(1, Math.floor((start.getTime() - date.getTime()) / 86_400_000))
+    const especeNom = culture.espece?.nom ?? culture.especeId
+    const planche = culture.planche?.nom
+    urgentes.push({
+      type: "tache-retard",
+      titre: `${kind} en retard de ${jours} jour${jours > 1 ? "s" : ""}`,
+      message: `${kind[0].toUpperCase()}${kind.slice(1)} « ${especeNom} »${
+        planche ? ` (planche ${planche})` : ""
+      } prévu le ${formatDateFr(date.toISOString().split("T")[0])} et toujours non fait.`,
+      key: `tache-retard:${kind}:${culture.id}`,
+    })
+  }
+  return urgentes
+}
+
+/** Toutes les alertes urgentes détectables pour un utilisateur. */
+export async function detecterAlertesUrgentes(userId: string): Promise<AlerteUrgente[]> {
+  const [irrigations, associations, retards] = await Promise.all([
+    detecterIrrigationsInutiles(userId),
+    detecterAssociationsIncompatibles(userId),
+    detecterTachesEnRetard(userId),
+  ])
+  return [...irrigations, ...associations, ...retards]
+}

--- a/src/lib/notifications/resume.test.ts
+++ b/src/lib/notifications/resume.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest"
+import { construireResume, grouperTachesParType, nombreTachesAFaire } from "./resume"
+import { getMeteoIntervalMinutes, getResumeCronExpression, parseHeureResume } from "./config"
+import type { TacheJour } from "./types"
+
+const tacheSemis: TacheJour = {
+  id: 1,
+  type: "semis",
+  especeNom: "Carotte",
+  varieteNom: null,
+  plancheName: "S1",
+  ilot: "A",
+  date: "2026-08-10T08:00:00.000Z",
+  fait: false,
+  couleur: "#22c55e",
+}
+
+const tacheIrrigation: TacheJour = {
+  id: 2,
+  type: "irrigation",
+  especeNom: "Tomate + Laitue",
+  varieteNom: null,
+  plancheName: "S4",
+  ilot: "A",
+  date: "2026-08-10T06:00:00.000Z",
+  fait: false,
+  couleur: "#0ea5e9",
+  pluiePrevue: 8,
+  probablementInutile: true,
+}
+
+const tacheRecolteFait: TacheJour = {
+  id: 3,
+  type: "recolte",
+  especeNom: "Courgette",
+  varieteNom: null,
+  plancheName: null,
+  ilot: null,
+  date: "2026-08-10T10:00:00.000Z",
+  fait: true,
+  couleur: null,
+}
+
+describe("construireResume", () => {
+  it("assemble un résumé avec date par défaut", () => {
+    const resume = construireResume([tacheSemis], [])
+    expect(resume.taches).toHaveLength(1)
+    expect(resume.alertesMeteo).toHaveLength(0)
+    expect(resume.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it("trie les tâches par date puis par type", () => {
+    const resume = construireResume([tacheSemis, tacheIrrigation, tacheRecolteFait], [])
+    expect(resume.taches.map((t) => t.id)).toEqual([2, 1, 3])
+  })
+
+  it("trie les alertes météo par date", () => {
+    const resume = construireResume([], [
+      { type: "canicule", date: "2026-08-12", niveau: "attention", message: "x", details: "y", key: "canicule:2026-08-12" },
+      { type: "gel", date: "2026-08-10", niveau: "attention", message: "x", details: "y", key: "gel:2026-08-10" },
+    ])
+    expect(resume.alertesMeteo.map((a) => a.date)).toEqual(["2026-08-10", "2026-08-12"])
+  })
+})
+
+describe("grouperTachesParType / nombreTachesAFaire", () => {
+  it("regroupe par type", () => {
+    const groupes = grouperTachesParType([tacheSemis, tacheIrrigation, tacheRecolteFait])
+    expect(groupes.get("semis")).toHaveLength(1)
+    expect(groupes.get("irrigation")).toHaveLength(1)
+    expect(groupes.get("recolte")).toHaveLength(1)
+  })
+
+  it("compte les tâches restant à faire", () => {
+    expect(nombreTachesAFaire([tacheSemis, tacheIrrigation, tacheRecolteFait])).toBe(2)
+  })
+})
+
+describe("config du scheduler", () => {
+  it("parse HH:MM valide", () => {
+    expect(parseHeureResume("07:00")).toEqual({ hour: 7, minute: 0 })
+    expect(parseHeureResume("23:59")).toEqual({ hour: 23, minute: 59 })
+  })
+
+  it("rejette les heures invalides", () => {
+    expect(parseHeureResume("24:00")).toBeNull()
+    expect(parseHeureResume("07:60")).toBeNull()
+    expect(parseHeureResume("abc")).toBeNull()
+    expect(parseHeureResume(undefined)).toBeNull()
+  })
+
+  it("génère l'expression cron du résumé (défaut 07:00)", () => {
+    expect(getResumeCronExpression({})).toBe("0 7 * * *")
+    expect(getResumeCronExpression({ NOTIF_RESUME_HEURE: "06:45" })).toBe("45 6 * * *")
+    expect(getResumeCronExpression({ NOTIF_RESUME_HEURE: "invalide" })).toBe("0 7 * * *")
+  })
+
+  it("borne l'intervalle météo (défaut 30, min 5)", () => {
+    expect(getMeteoIntervalMinutes({})).toBe(30)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "10" })).toBe(10)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "2" })).toBe(5)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "99999" })).toBe(1440)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "abc" })).toBe(30)
+  })
+})

--- a/src/lib/notifications/resume.ts
+++ b/src/lib/notifications/resume.ts
@@ -1,0 +1,96 @@
+/**
+ * Assemblage PUR du résumé quotidien « Quoi faire ce matin ? ».
+ * La partie base de données vit dans `queries.ts` ; ici tout est testable
+ * sans Prisma ni réseau.
+ */
+
+import { dateLocaleIso } from "./detect"
+import type { AlerteMeteoNotification, ResumeQuotidien, TacheJour, TypeTache } from "./types"
+
+/** Trie les tâches par date puis par type, et les alertes par date. */
+export function construireResume(
+  taches: TacheJour[],
+  alertes: AlerteMeteoNotification[],
+  options: { date?: string } = {}
+): ResumeQuotidien {
+  return {
+    date: options.date ?? dateLocaleIso(),
+    taches: [...taches].sort(
+      (a, b) =>
+        new Date(a.date).getTime() - new Date(b.date).getTime() ||
+        ordreTypeTache(a.type) - ordreTypeTache(b.type)
+    ),
+    alertesMeteo: [...alertes].sort((a, b) => a.date.localeCompare(b.date)),
+  }
+}
+
+const ORDRE_TYPES: Record<TypeTache, number> = {
+  semis: 0,
+  plantation: 1,
+  recolte: 2,
+  irrigation: 3,
+}
+
+function ordreTypeTache(type: TypeTache): number {
+  return ORDRE_TYPES[type] ?? 99
+}
+
+export function labelTypeTache(type: TypeTache): string {
+  switch (type) {
+    case "semis":
+      return "Semis"
+    case "plantation":
+      return "Plantations"
+    case "recolte":
+      return "Récoltes"
+    case "irrigation":
+      return "Irrigations"
+  }
+}
+
+export function labelAlerteMeteo(type: AlerteMeteoNotification["type"]): string {
+  switch (type) {
+    case "gel":
+      return "gel attendu"
+    case "orage":
+      return "orage en cours"
+    case "canicule":
+      return "canicule"
+    case "vent":
+      return "vent fort"
+    case "pluie":
+      return "pluie abondante"
+  }
+}
+
+/** Libellé court d'une alerte pour l'objet de l'email (« gel attendu »). */
+export function labelAlerteMeteoCourt(type: AlerteMeteoNotification["type"]): string {
+  switch (type) {
+    case "gel":
+      return "gel attendu"
+    case "orage":
+      return "orage"
+    case "canicule":
+      return "canicule"
+    case "vent":
+      return "vent fort"
+    case "pluie":
+      return "pluie abondante"
+  }
+}
+
+/** Regroupe les tâches par type pour le rendu en sections. */
+export function grouperTachesParType(taches: TacheJour[]): Map<TypeTache, TacheJour[]> {
+  const groupes = new Map<TypeTache, TacheJour[]>()
+  for (const tache of taches) {
+    const liste = groupes.get(tache.type) ?? []
+    liste.push(tache)
+    groupes.set(tache.type, liste)
+  }
+  return groupes
+}
+
+/** Nombre de tâches restant à faire (pour le pied du résumé). */
+export function nombreTachesAFaire(taches: TacheJour[]): number {
+  return taches.filter((t) => !t.fait).length
+}

--- a/src/lib/notifications/scheduler.ts
+++ b/src/lib/notifications/scheduler.ts
@@ -1,0 +1,95 @@
+/**
+ * Scheduler interne au conteneur (node-cron), initialisé au démarrage du
+ * serveur Next.js via `src/instrumentation.ts` (register()).
+ *
+ * - Résumé quotidien : horaire fixe NOTIF_RESUME_HEURE (défaut 07:00).
+ * - Surveillance météo + urgences : toutes les NOTIF_METEO_INTERVAL_MIN
+ *   minutes (défaut 30), plus un premier scan ~30 s après le boot.
+ *
+ * Robustesse : l'init est enveloppé en try/catch (ne fait jamais crasher le
+ * démarrage) ; chaque run est isolé et ne peut pas se chevaucher avec le
+ * précédent.
+ */
+
+import cron from "node-cron"
+import { getMeteoIntervalMinutes, getResumeCronExpression } from "./config"
+import { envoyerAlertesMeteoTempsReel, envoyerAlertesUrgentes, envoyerResumeQuotidien, notificationsEnabled } from "./sender"
+
+let initialized = false
+
+/** Délai avant le premier scan au démarrage (laisse la DB se réveiller). */
+const DELAI_PREMIER_SCAN_MS = 30_000
+
+let scanEnCours = false
+
+async function runScanMeteoEtUrgent(): Promise<void> {
+  if (scanEnCours) {
+    console.warn("[notifications] Scan précédent encore en cours, saut de cycle")
+    return
+  }
+  scanEnCours = true
+  try {
+    const meteo = await envoyerAlertesMeteoTempsReel()
+    const urgentes = await envoyerAlertesUrgentes()
+    if (meteo > 0 || urgentes > 0) {
+      console.log(`[notifications] Scan : ${meteo} alerte(s) météo, ${urgentes} action(s) urgente(s) envoyée(s)`)
+    }
+  } catch (error) {
+    console.error("[notifications] Échec du scan météo/urgent:", error)
+  } finally {
+    scanEnCours = false
+  }
+}
+
+/**
+ * Initialise le scheduler. Appelé une seule fois (module-level flag) depuis
+ * instrumentation.register(). Ne lève jamais.
+ */
+export function initNotifScheduler(): void {
+  if (initialized) return
+  // Pendant `next build`, register() peut être exécuté par le serveur de
+  // compilation : on ne planifie rien.
+  if (process.env.NEXT_PHASE === "phase-production-build") return
+
+  initialized = true
+  try {
+    if (!notificationsEnabled()) {
+      console.log(
+        "[notifications] Désactivées — définir SMTP_HOST/SMTP_USER (ou NOTIF_ENABLED=true après configuration SMTP)"
+      )
+      return
+    }
+
+    const intervalMinutes = getMeteoIntervalMinutes()
+    const resumeExpression = getResumeCronExpression()
+
+    // Premier scan au démarrage (météo + urgences), après un court délai.
+    setTimeout(() => {
+      runScanMeteoEtUrgent().catch((error) => console.error("[notifications] Premier scan en échec:", error))
+    }, DELAI_PREMIER_SCAN_MS)
+
+    // Surveillance météo + urgences à intervalle régulier.
+    cron.schedule(`*/${intervalMinutes} * * * *`, () => {
+      runScanMeteoEtUrgent().catch((error) => console.error("[notifications] Scan planifié en échec:", error))
+    })
+
+    // Résumé quotidien à l'heure configurée (fuseau du conteneur, TZ).
+    cron.schedule(
+      resumeExpression,
+      () => {
+        envoyerResumeQuotidien()
+          .then((n) => {
+            if (n > 0) console.log(`[notifications] Résumé quotidien envoyé à ${n} destinataire(s)`)
+          })
+          .catch((error) => console.error("[notifications] Résumé quotidien en échec:", error))
+      },
+      { timezone: process.env.TZ || "Europe/Paris" }
+    )
+
+    console.log(
+      `[notifications] Scheduler démarré — résumé quotidien à ${resumeExpression} (NOTIF_RESUME_HEURE) — scan météo/urgent toutes les ${intervalMinutes} min`
+    )
+  } catch (error) {
+    console.error("[notifications] Impossible de démarrer le scheduler:", error)
+  }
+}

--- a/src/lib/notifications/sender.ts
+++ b/src/lib/notifications/sender.ts
@@ -1,0 +1,151 @@
+/**
+ * Orchestration des envois : résumé quotidien + alertes temps réel.
+ *
+ * Chaque exécution est isolée (try/catch par utilisateur et par étape) :
+ * une erreur de météo, de SMTP ou de base ne fait jamais tomber le cron.
+ * L'anti-redondance (store en mémoire) est scellée par utilisateur pour
+ * que chaque compte reçoive bien ses propres alertes.
+ */
+
+import { sendMail } from "@/lib/mail"
+import {
+  chargerTachesDuJour,
+  detecterAlertesUrgentes,
+  getDestinatairesNotifications,
+  getCoordsUtilisateur,
+  recupererAlertesMeteoJour,
+} from "./queries"
+import {
+  alerteDejaEnvoyee,
+  marquerAlerteEnvoyee,
+  nettoyerAlertesEnvoyees,
+} from "./store"
+import { detecterAlertesMeteo } from "./detect"
+import { construireResume } from "./resume"
+import { alerteMeteoEmail, alerteUrgenteEmail, resumeQuotidienEmail } from "./templates"
+import type { AlerteMeteoNotification, DestinataireNotification } from "./types"
+import { fetchOpenMeteoForecast } from "@/lib/meteo"
+
+/** Nombre maximal d'emails envoyés par utilisateur et par scan (anti-spam). */
+const MAX_EMAILS_PAR_UTILISATEUR = 15
+
+/** Les notifications sont-elles activées ? (défaut : oui si SMTP configuré). */
+export function notificationsEnabled(): boolean {
+  if (process.env.NOTIF_ENABLED === "false") return false
+  return Boolean(process.env.SMTP_HOST && process.env.SMTP_USER)
+}
+
+/**
+ * Scan météo temps réel : pour chaque utilisateur, détecte les conditions
+ * dangereuses sur les 48 h à venir et email chaque nouvelle alerte.
+ */
+export async function envoyerAlertesMeteoTempsReel(): Promise<number> {
+  if (!notificationsEnabled()) return 0
+  nettoyerAlertesEnvoyees()
+  const users = await getDestinatairesNotifications()
+  let total = 0
+  for (const user of users) {
+    try {
+      total += await traiterMeteoUtilisateur(user)
+    } catch (error) {
+      console.error(`[notifications] Scan météo échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}
+
+async function traiterMeteoUtilisateur(user: DestinataireNotification): Promise<number> {
+  const coords = await getCoordsUtilisateur(user.id)
+  if (coords.length === 0) return 0
+
+  const alertes: AlerteMeteoNotification[] = []
+  for (const { lat, lng } of coords) {
+    try {
+      const { current, daily } = await fetchOpenMeteoForecast(lat, lng)
+      // Temps réel = conditions actuelles + 48 h (gel de la nuit, canicule du lendemain…)
+      alertes.push(...detecterAlertesMeteo(daily, current, { horizonJours: 2 }))
+    } catch (error) {
+      console.warn(`[notifications] Prévisions indisponibles (${lat},${lng}):`, error)
+    }
+  }
+
+  // Déduplication au sein d'un même scan (2 parcelles proches → 1 email)
+  const envoyees = new Set<string>()
+  let total = 0
+  for (const alerte of alertes) {
+    if (total >= MAX_EMAILS_PAR_UTILISATEUR) {
+      console.warn(`[notifications] Cap anti-spam atteint pour ${user.email}`)
+      break
+    }
+    const cle = `${user.id}:${alerte.key}`
+    if (envoyees.has(cle) || alerteDejaEnvoyee(cle)) continue
+    try {
+      const { subject, html } = alerteMeteoEmail(user, alerte)
+      await sendMail({ to: user.email, subject, html })
+      marquerAlerteEnvoyee(cle, { until: alerte.date })
+      envoyees.add(cle)
+      total++
+    } catch (error) {
+      console.error(`[notifications] Envoi alerte météo échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}
+
+/**
+ * Scan temps réel des actions urgentes : irrigations probablement inutiles,
+ * associations incompatibles, tâches en retard.
+ */
+export async function envoyerAlertesUrgentes(): Promise<number> {
+  if (!notificationsEnabled()) return 0
+  const users = await getDestinatairesNotifications()
+  let total = 0
+  for (const user of users) {
+    try {
+      const urgentes = await detecterAlertesUrgentes(user.id)
+      let envoyees = 0
+      for (const alerte of urgentes) {
+        if (envoyees >= MAX_EMAILS_PAR_UTILISATEUR) {
+          console.warn(`[notifications] Cap anti-spam atteint pour ${user.email}`)
+          break
+        }
+        const cle = `${user.id}:${alerte.key}`
+        if (alerteDejaEnvoyee(cle)) continue
+        try {
+          const { subject, html } = alerteUrgenteEmail(user, alerte)
+          await sendMail({ to: user.email, subject, html })
+          marquerAlerteEnvoyee(cle)
+          envoyees++
+        } catch (error) {
+          console.error(`[notifications] Envoi alerte urgente échoué pour ${user.email}:`, error)
+        }
+      }
+      total += envoyees
+    } catch (error) {
+      console.error(`[notifications] Scan urgent échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}
+
+/** Résumé quotidien « Quoi faire ce matin ? » pour chaque utilisateur. */
+export async function envoyerResumeQuotidien(): Promise<number> {
+  if (!notificationsEnabled()) return 0
+  const users = await getDestinatairesNotifications()
+  let total = 0
+  for (const user of users) {
+    try {
+      const [taches, alertesMeteo] = await Promise.all([
+        chargerTachesDuJour(user.id),
+        recupererAlertesMeteoJour(user.id),
+      ])
+      const resume = construireResume(taches, alertesMeteo)
+      const { subject, html } = resumeQuotidienEmail(user, resume)
+      await sendMail({ to: user.email, subject, html })
+      total++
+    } catch (error) {
+      console.error(`[notifications] Résumé quotidien échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}

--- a/src/lib/notifications/store.test.ts
+++ b/src/lib/notifications/store.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  alerteDejaEnvoyee,
+  marquerAlerteEnvoyee,
+  nettoyerAlertesEnvoyees,
+  nombreAlertesMemorisees,
+  resetStorePourTests,
+} from "./store"
+
+function hierIso(): string {
+  const hier = new Date()
+  hier.setDate(hier.getDate() - 1)
+  const m = String(hier.getMonth() + 1).padStart(2, "0")
+  const d = String(hier.getDate()).padStart(2, "0")
+  return `${hier.getFullYear()}-${m}-${d}`
+}
+
+describe("store anti-redondance", () => {
+  beforeEach(() => {
+    resetStorePourTests()
+  })
+
+  it("une alerte non envoyée n'est pas mémorisée", () => {
+    expect(alerteDejaEnvoyee("gel:2026-08-10")).toBe(false)
+    expect(nombreAlertesMemorisees()).toBe(0)
+  })
+
+  it("bloque une seconde notification de la même alerte active", () => {
+    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
+    expect(alerteDejaEnvoyee("u1:gel:2026-08-10")).toBe(true)
+  })
+
+  it("l'anti-redondance est scellée par utilisateur", () => {
+    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
+    // L'utilisateur 2 dans la même région doit bien être notifié
+    expect(alerteDejaEnvoyee("u2:gel:2026-08-10")).toBe(false)
+  })
+
+  it("libère l'alerte une fois sa date passée (re-notification possible)", () => {
+    const hier = hierIso()
+    marquerAlerteEnvoyee(`u1:gel:${hier}`, { until: hier })
+    expect(alerteDejaEnvoyee(`u1:gel:${hier}`)).toBe(false)
+  })
+
+  it("les entrées expirées sont purgées par nettoyerAlertesEnvoyees", () => {
+    const hier = hierIso()
+    marquerAlerteEnvoyee(`u1:gel:${hier}`, { until: hier })
+    marquerAlerteEnvoyee("u1:canicule:2099-01-01")
+    expect(nombreAlertesMemorisees()).toBe(2)
+    nettoyerAlertesEnvoyees()
+    expect(nombreAlertesMemorisees()).toBe(1)
+  })
+
+  it("une alerte sans date de validité reste mémorisée", () => {
+    marquerAlerteEnvoyee("u1:tache-retard:semis:123")
+    expect(alerteDejaEnvoyee("u1:tache-retard:semis:123")).toBe(true)
+  })
+})

--- a/src/lib/notifications/store.test.ts
+++ b/src/lib/notifications/store.test.ts
@@ -15,6 +15,14 @@ function hierIso(): string {
   return `${hier.getFullYear()}-${m}-${d}`
 }
 
+function demainIso(): string {
+  const demain = new Date()
+  demain.setDate(demain.getDate() + 1)
+  const m = String(demain.getMonth() + 1).padStart(2, "0")
+  const d = String(demain.getDate()).padStart(2, "0")
+  return `${demain.getFullYear()}-${m}-${d}`
+}
+
 describe("store anti-redondance", () => {
   beforeEach(() => {
     resetStorePourTests()
@@ -26,14 +34,16 @@ describe("store anti-redondance", () => {
   })
 
   it("bloque une seconde notification de la même alerte active", () => {
-    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
-    expect(alerteDejaEnvoyee("u1:gel:2026-08-10")).toBe(true)
+    const demain = demainIso()
+    marquerAlerteEnvoyee(`u1:gel:${demain}`, { until: demain })
+    expect(alerteDejaEnvoyee(`u1:gel:${demain}`)).toBe(true)
   })
 
   it("l'anti-redondance est scellée par utilisateur", () => {
-    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
+    const demain = demainIso()
+    marquerAlerteEnvoyee(`u1:gel:${demain}`, { until: demain })
     // L'utilisateur 2 dans la même région doit bien être notifié
-    expect(alerteDejaEnvoyee("u2:gel:2026-08-10")).toBe(false)
+    expect(alerteDejaEnvoyee(`u2:gel:${demain}`)).toBe(false)
   })
 
   it("libère l'alerte une fois sa date passée (re-notification possible)", () => {

--- a/src/lib/notifications/store.ts
+++ b/src/lib/notifications/store.ts
@@ -1,0 +1,71 @@
+/**
+ * Anti-redondance des notifications : store EN MÉMOIRE des alertes déjà
+ * envoyées.
+ *
+ * Chaque clé est propre à (utilisateur, alerte) — le sender préfixe par
+ * l'id utilisateur. Les entrées sont purgées dès que leur date de validité
+ * (`until`) est dépassée ou après TTL (7 jours), ce qui permet de
+ * re-notifier une alerte qui revient (ex. gel une autre nuit).
+ *
+ * Volontairement sans dépendance : un store en mémoire évite toute migration
+ * de schéma Prisma et tout risque sur l'instance en production. Au pire un
+ * redémarrage du conteneur peut re-émettre une alerte du jour — acceptable,
+ * et le TTL limite l'accumulation.
+ */
+
+export interface EntreeAlerteEnvoyee {
+  sentAt: number // epoch ms
+  /** Date (YYYY-MM-DD) jusqu'à laquelle l'alerte reste « déjà notifiée ». */
+  until?: string
+}
+
+const TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 jours
+
+const sentAlerts = new Map<string, EntreeAlerteEnvoyee>()
+
+/** Date du jour locale (YYYY-MM-DD) pour les comparaisons d'expiration. */
+function todayKey(): string {
+  const now = new Date()
+  const m = String(now.getMonth() + 1).padStart(2, "0")
+  const d = String(now.getDate()).padStart(2, "0")
+  return `${now.getFullYear()}-${m}-${d}`
+}
+
+/**
+ * L'alerte (clé `key`) a-t-elle déjà été notifiée et est-elle encore active ?
+ */
+export function alerteDejaEnvoyee(key: string): boolean {
+  const entry = sentAlerts.get(key)
+  if (!entry) return false
+  if (entry.until && entry.until < todayKey()) {
+    // L'alerte date d'un jour passé → elle ne bloque plus
+    sentAlerts.delete(key)
+    return false
+  }
+  return true
+}
+
+/** Marque une alerte comme envoyée, avec sa date de validité éventuelle. */
+export function marquerAlerteEnvoyee(key: string, options: { until?: string } = {}): void {
+  sentAlerts.set(key, { sentAt: Date.now(), until: options.until })
+}
+
+/** Purge les entrées expirées ou trop anciennes (appelé à chaque scan). */
+export function nettoyerAlertesEnvoyees(): void {
+  const today = todayKey()
+  for (const [key, entry] of sentAlerts) {
+    const expirée = entry.until !== undefined && entry.until < today
+    const tropVieille = Date.now() - entry.sentAt > TTL_MS
+    if (expirée || tropVieille) sentAlerts.delete(key)
+  }
+}
+
+/** Nombre d'entrées actuellement mémorisées (diagnostic / tests). */
+export function nombreAlertesMemorisees(): number {
+  return sentAlerts.size
+}
+
+/** Vide le store — réservé aux tests. */
+export function resetStorePourTests(): void {
+  sentAlerts.clear()
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -4,7 +4,7 @@
  */
 
 import { APP_URL, escapeHtml } from "@/lib/mail"
-import { formatDateFr } from "./detect"
+import { formatDateFr, formaterTemporaliteAlerte, indicationHoraireAlerte } from "./detect"
 import { labelAlerteMeteoCourt, labelTypeTache, nombreTachesAFaire } from "./resume"
 import type { AlerteMeteoNotification, AlerteUrgente, DestinataireNotification, ResumeQuotidien } from "./types"
 
@@ -154,6 +154,12 @@ export function alerteMeteoEmail(
       headerSubtitle: alerte.niveau === "danger" ? "Niveau danger" : "Niveau attention",
       accent: alerte.niveau === "danger" ? "red" : "amber",
       content: `
+        <p style="margin:0 0 6px;font-size:14px;color:#1e293b;">
+          <strong>Quand :</strong> ${escapeHtml(formaterTemporaliteAlerte(alerte.date))}
+        </p>
+        <p style="margin:0 0 14px;font-size:13px;color:#64748b;font-style:italic;">
+          ${escapeHtml(indicationHoraireAlerte(alerte.type))}
+        </p>
         <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
           ${escapeHtml(alerte.message)}.
         </p>

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -1,0 +1,201 @@
+/**
+ * Templates HTML des emails de notifications métier.
+ * Même style que les autres emails Gleba (layout table, dégradé vert).
+ */
+
+import { APP_URL, escapeHtml } from "@/lib/mail"
+import { formatDateFr } from "./detect"
+import { labelAlerteMeteoCourt, labelTypeTache, nombreTachesAFaire } from "./resume"
+import type { AlerteMeteoNotification, AlerteUrgente, DestinataireNotification, ResumeQuotidien } from "./types"
+
+function layoutNotification(options: {
+  headerTitle: string
+  headerSubtitle?: string
+  accent?: "red" | "amber" | "green"
+  content: string
+}): string {
+  const accent = options.accent ?? "green"
+  const gradient =
+    accent === "red"
+      ? "linear-gradient(135deg,#b91c1c,#ef4444)"
+      : accent === "amber"
+        ? "linear-gradient(135deg,#b45309,#f59e0b)"
+        : "linear-gradient(135deg,#065f46,#0d9488)"
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;padding:40px 20px;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+        <tr>
+          <td style="background:${gradient};padding:28px 40px;text-align:center;">
+            <h1 style="margin:0;font-size:22px;font-weight:300;color:#ffffff;">${escapeHtml(options.headerTitle)}</h1>
+            ${options.headerSubtitle ? `<p style="margin:8px 0 0;font-size:13px;color:#ffffff;opacity:0.9;">${escapeHtml(options.headerSubtitle)}</p>` : ""}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px 40px;">
+            ${options.content}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 40px 28px;border-top:1px solid #f1f5f9;">
+            <p style="margin:0;font-size:12px;color:#94a3b8;text-align:center;">
+              Gleba — Gestion agricole · <a href="${APP_URL}" style="color:#10b981;text-decoration:none;">${APP_URL}</a>
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`
+}
+
+function tacheLigne(tache: ResumeQuotidien["taches"][number]): string {
+  const localisation = tache.plancheName
+    ? ` — ${escapeHtml(tache.plancheName)}${tache.ilot ? ` (ilot ${escapeHtml(tache.ilot)})` : ""}`
+    : ""
+  const variete = tache.varieteNom ? ` <span style="color:#64748b">(${escapeHtml(tache.varieteNom)})</span>` : ""
+  const irrigationInfo =
+    tache.type === "irrigation" && tache.probablementInutile
+      ? `<span style="color:#b45309;font-size:12px;"> — probablement inutile${tache.pluiePrevue != null ? ` (${tache.pluiePrevue} mm prévus)` : ""}</span>`
+      : ""
+  const badge = tache.fait
+    ? `<span style="color:#059669;font-weight:600;">✓ fait</span>`
+    : `<span style="color:#b45309;font-weight:600;">à faire</span>`
+  return `<tr>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:14px;color:#1e293b;">
+      <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${escapeHtml(tache.couleur ?? "#94a3b8")};margin-right:8px;"></span>
+      <strong>${escapeHtml(tache.especeNom)}</strong>${variete}${localisation}
+    </td>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:12px;color:#475569;text-align:right;">${escapeHtml(labelTypeTache(tache.type))}${irrigationInfo}</td>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:13px;text-align:right;">${badge}</td>
+  </tr>`
+}
+
+export function resumeQuotidienEmail(
+  user: DestinataireNotification,
+  resume: ResumeQuotidien
+): { subject: string; html: string } {
+  const dateLabel = formatDateFr(resume.date)
+  const prenom = user.name ? user.name.split(" ")[0] : ""
+
+  const sections: string[] = []
+  if (resume.taches.length > 0) {
+    const lignes = resume.taches.map(tacheLigne).join("")
+    sections.push(`
+      <h2 style="margin:0 0 12px;font-size:16px;font-weight:600;color:#1e293b;">Tâches du jour</h2>
+      <table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e2e8f0;border-radius:10px;overflow:hidden;border-collapse:collapse;">
+        ${lignes}
+      </table>`)
+  } else {
+    sections.push(`
+      <div style="background:#f8fafc;border-radius:10px;padding:16px 20px;border-left:3px solid #0d9488;">
+        <p style="margin:0;font-size:14px;color:#475569;">Rien de prévu aujourd'hui sur le calendrier.</p>
+      </div>`)
+  }
+
+  if (resume.alertesMeteo.length > 0) {
+    const alertesHtml = resume.alertesMeteo
+      .map(
+        (a) => `
+        <div style="background:${a.niveau === "danger" ? "#fef2f2" : "#fffbeb"};border-radius:10px;padding:12px 16px;border-left:3px solid ${a.niveau === "danger" ? "#dc2626" : "#f59e0b"};margin-bottom:10px;">
+          <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">${escapeHtml(a.message)}</p>
+          <p style="margin:6px 0 0;font-size:13px;color:#475569;line-height:1.5;">${escapeHtml(a.details)}</p>
+        </div>`
+      )
+      .join("")
+    sections.push(`
+      <h2 style="margin:24px 0 12px;font-size:16px;font-weight:600;color:#1e293b;">Météo du jour</h2>
+      ${alertesHtml}`)
+  }
+
+  const aFaire = nombreTachesAFaire(resume.taches)
+  const conclusion =
+    aFaire > 0
+      ? `<p style="margin:20px 0 0;font-size:14px;color:#475569;">Bon courage : ${aFaire} action${aFaire > 1 ? "s" : ""} à mener aujourd'hui.</p>`
+      : resume.alertesMeteo.length > 0
+        ? `<p style="margin:20px 0 0;font-size:14px;color:#475569;">Pensez à consulter les alertes météo ci-dessus avant de commencer.</p>`
+        : ""
+
+  return {
+    subject: `[Gleba] Résumé du jour - ${dateLabel}`,
+    html: layoutNotification({
+      headerTitle: `Quoi faire ce matin ?`,
+      headerSubtitle: `Résumé du jour — ${dateLabel}`,
+      content: `
+        ${prenom ? `<p style="margin:0 0 20px;font-size:15px;color:#1e293b;">Bonjour ${escapeHtml(prenom)},</p>` : ""}
+        ${sections.join("")}
+        ${conclusion}
+        <table cellpadding="0" cellspacing="0" style="margin:24px 0 0;">
+          <tr>
+            <td style="background:linear-gradient(135deg,#059669,#0d9488);border-radius:10px;">
+              <a href="${APP_URL}/calendrier" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                Voir le calendrier →
+              </a>
+            </td>
+          </tr>
+        </table>`,
+    }),
+  }
+}
+
+export function alerteMeteoEmail(
+  user: DestinataireNotification,
+  alerte: AlerteMeteoNotification
+): { subject: string; html: string } {
+  const libelle = labelAlerteMeteoCourt(alerte.type)
+  return {
+    subject: `[Gleba] Alerte météo : ${libelle}${alerte.type === "gel" || alerte.type === "canicule" || alerte.type === "vent" || alerte.type === "pluie" ? ` (${formatDateFr(alerte.date)})` : ""}`,
+    html: layoutNotification({
+      headerTitle: `Alerte météo : ${libelle}`,
+      headerSubtitle: alerte.niveau === "danger" ? "Niveau danger" : "Niveau attention",
+      accent: alerte.niveau === "danger" ? "red" : "amber",
+      content: `
+        <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
+          ${escapeHtml(alerte.message)}.
+        </p>
+        <div style="background:${alerte.niveau === "danger" ? "#fef2f2" : "#fffbeb"};border-radius:10px;padding:16px 20px;border-left:3px solid ${alerte.niveau === "danger" ? "#dc2626" : "#f59e0b"};">
+          <p style="margin:0;font-size:14px;color:#1e293b;line-height:1.6;">${escapeHtml(alerte.details)}</p>
+        </div>
+        <table cellpadding="0" cellspacing="0" style="margin:24px 0 0;">
+          <tr>
+            <td style="background:linear-gradient(135deg,#059669,#0d9488);border-radius:10px;">
+              <a href="${APP_URL}/meteo" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                Voir la météo →
+              </a>
+            </td>
+          </tr>
+        </table>`,
+    }),
+  }
+}
+
+export function alerteUrgenteEmail(
+  user: DestinataireNotification,
+  alerte: AlerteUrgente
+): { subject: string; html: string } {
+  return {
+    subject: `[Gleba] Action urgente : ${alerte.titre}`,
+    html: layoutNotification({
+      headerTitle: `Action urgente`,
+      headerSubtitle: alerte.titre,
+      accent: "red",
+      content: `
+        <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
+          ${escapeHtml(alerte.message)}
+        </p>
+        <table cellpadding="0" cellspacing="0" style="margin:24px 0 0;">
+          <tr>
+            <td style="background:linear-gradient(135deg,#059669,#0d9488);border-radius:10px;">
+              <a href="${APP_URL}/calendrier" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                Gérer dans Gleba →
+              </a>
+            </td>
+          </tr>
+        </table>`,
+    }),
+  }
+}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Types partagés du système de notifications métier (alertes par email).
+ * Logique pure : aucun import runtime — sûr pour les tests unitaires.
+ */
+
+/** Types d'alerte météo notifiés par email. */
+export type TypeAlerteMeteo = "gel" | "orage" | "canicule" | "vent" | "pluie"
+
+export interface AlerteMeteoNotification {
+  type: TypeAlerteMeteo
+  /** Date concernée (YYYY-MM-DD). */
+  date: string
+  niveau: "attention" | "danger"
+  message: string
+  details: string
+  /**
+   * Clé stable anti-redondance, propre à l'alerte (ex. `gel:2026-08-10`).
+   * Le sender la préfixe par l'id utilisateur avant d'écrire dans le store.
+   */
+  key: string
+}
+
+/** Type d'une action du calendrier / du résumé du jour. */
+export type TypeTache = "semis" | "plantation" | "recolte" | "irrigation"
+
+export interface TacheJour {
+  id: string | number
+  type: TypeTache
+  especeNom: string
+  varieteNom: string | null
+  plancheName: string | null
+  ilot: string | null
+  date: string // ISO
+  fait: boolean
+  couleur: string | null
+  /** Enrichissement irrigation : pluie prévue le jour J (mm). */
+  pluiePrevue?: number | null
+  /** Enrichissement irrigation : passage probablement inutile (pluie). */
+  probablementInutile?: boolean
+}
+
+export interface ResumeQuotidien {
+  /** Date du résumé (YYYY-MM-DD). */
+  date: string
+  taches: TacheJour[]
+  alertesMeteo: AlerteMeteoNotification[]
+}
+
+/** Types d'alertes urgentes (temps réel). */
+export type TypeAlerteUrgente = "irrigation-inutile" | "association-incompatible" | "tache-retard"
+
+export interface AlerteUrgente {
+  type: TypeAlerteUrgente
+  /** Titre court, repris dans l'objet de l'email (ex. « irrigation planche S4 »). */
+  titre: string
+  message: string
+  /**
+   * Clé stable anti-redondance propre à l'action
+   * (ex. `retard:semis:1234`). Préfixée par l'id utilisateur dans le store.
+   */
+  key: string
+}
+
+/** Destinataire d'une notification (user actif, email valide, pas d'opt-out). */
+export interface DestinataireNotification {
+  id: string
+  email: string
+  name: string | null
+}


### PR DESCRIPTION
## Objectif

Les alertes métiers de Gleba (météo, urgences, tâches) sont aujourd'hui uniquement visibles **in-app**. Cette PR les rend disponibles par **email**, selon un modèle de type ERP :

- **Alertes météo en temps réel** (gel, orage, canicule, vent fort, pluie abondante) : email immédiat dès détection, avec anti-redondance.
- **Actions urgentes en temps réel** (irrigation planifiée probablement inutile, association incompatible, tâche en retard) : email immédiat.
- **Résumé quotidien** « Quoi faire ce matin ? » : email matinal (défaut 07h00) récapitulant les tâches du jour (semis, plantations, récoltes, irrigations) + météo.

## Mécanisme

- **Scheduler `node-cron`** initialisé au boot du serveur via `src/instrumentation.ts` (pattern Next.js 16, garde `NEXT_PHASE` build).
- **Résumé quotidien** : `NOTIF_RESUME_HEURE` (défaut `07:00`).
- **Surveillance météo/urgences** : `NOTIF_METEO_INTERVAL_MIN` (défaut `30`, premier scan à +30 s après boot).
- **Anti-spam** : plafond de 15 emails/utilisateur/scan + persistance de l'état d'alerte active pour ne pas re-notifier la même alerte.

## Configuration

Variables ajoutées à `.env.example` (et passées au conteneur via `docker-compose.yml`) :

| Variable | Défaut | Rôle |
|---|---|---|
| `NOTIF_ENABLED` | `true` | Activer/désactiver tout le système |
| `NOTIF_RESUME_HEURE` | `07:00` | Heure du résumé quotidien |
| `NOTIF_METEO_INTERVAL_MIN` | `30` | Intervalle de surveillance météo/urgences |

Les emails sont envoyés via le SMTP existant (`src/lib/mail.ts`, nodemailer). L'URL publique des liens est dérivée de `NEXTAUTH_URL` (const `APP_URL`).

## Validation

- `npx tsc --noEmit` → 0 erreur
- `npm run build` → compilé (291 pages)
- **26 nouveaux tests Vitest** passent (détection seuils, anti-redondance, résumé, config cron)
- Suite existante : 772/774 (2 échecs pré-existants — growth-campaign & irrigation-recording — non liés)

## Note

- Un rebuild Docker (`docker compose up -d --build`) est nécessaire pour embarquer la dépendance `node-cron`.