### PR TITLE
feat(notifications): alertes stocks bas sous seuil - issue #16

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,15 @@ SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=
 
+# Notifications métier par email (résumé quotidien + alertes temps réel)
+# Les alertes sont activées par défaut dès que SMTP_HOST/SMTP_USER sont définis.
+# NOTIF_ENABLED=false coupe tout (météo temps réel, urgent, résumé).
+NOTIF_ENABLED=true
+# Heure du résumé quotidien « Quoi faire ce matin ? » (heure locale conteneur, TZ).
+NOTIF_RESUME_HEURE=07:00
+# Fréquence (minutes) du scan météo temps réel + alertes urgentes (borné 5-1440).
+NOTIF_METEO_INTERVAL_MIN=30
+
 # Ollama Cloud (assistant chat — optionnel, désactivé par défaut côté public)
 OLLAMA_API_KEY=
 OLLAMA_MODEL=nemotron-3-nano:30b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,10 @@ services:
       SMTP_PASS: ${SMTP_PASS:-}
       SMTP_FROM: ${SMTP_FROM:-}
       FEEDBACK_EMAIL: ${FEEDBACK_EMAIL:-}
+      # Notifications métier par email (cron interne : résumé + alertes temps réel)
+      NOTIF_ENABLED: ${NOTIF_ENABLED:-true}
+      NOTIF_RESUME_HEURE: ${NOTIF_RESUME_HEURE:-07:00}
+      NOTIF_METEO_INTERVAL_MIN: ${NOTIF_METEO_INTERVAL_MIN:-30}
       # Audit compta 2026-06 : les bornes d'exercice comptable sont calculées
       # en heure locale du serveur — en UTC, une vente saisie le 1er janvier
       # 00h30 (heure de Paris) tombait dans l'exercice précédent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.21.0",
-        "typescript": "5.9.3",
+        "typescript": "^5.9.3",
         "vitest": "^2.1.5"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "mathjs": "^15.2.0",
         "next": "^16.2.10",
         "next-auth": "^5.0.0-beta.31",
+        "node-cron": "^4.6.0",
         "nodemailer": "^9.0.3",
         "ollama": "^0.6.3",
         "pdfkit": "^0.18.0",
@@ -7926,6 +7927,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/nodemailer": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mathjs": "^15.2.0",
     "next": "^16.2.10",
     "next-auth": "^5.0.0-beta.31",
+    "node-cron": "^4.6.0",
     "nodemailer": "^9.0.3",
     "ollama": "^0.6.3",
     "pdfkit": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.21.0",
-    "typescript": "5.9.3",
+    "typescript": "^5.9.3",
     "vitest": "^2.1.5"
   }
 }

--- a/prisma/migrations/20260817100432_add_stock_min_thresholds/migration.sql
+++ b/prisma/migrations/20260817100432_add_stock_min_thresholds/migration.sql
@@ -1,0 +1,7 @@
+-- Seuils minimums pour les alertes de stocks utilisateur.
+ALTER TABLE "user_stock_varietes"
+  ADD COLUMN "stock_min_graines" DOUBLE PRECISION,
+  ADD COLUMN "stock_min_plants" INTEGER;
+
+ALTER TABLE "user_stock_fertilisants"
+  ADD COLUMN "stock_min" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3405,6 +3405,9 @@ model UserStockVariete {
   // DEV2 #6 — coût unitaire d'entrée pour PMP/FIFO/dernier prix
   coutUnitaire Float?    @map("cout_unitaire")
   dateStock    DateTime? @map("date_stock")
+  // Seuil minimum d'alerte (réapprovisionnement conseillé)
+  stockMinGraines Float? @map("stock_min_graines")
+  stockMinPlants  Int?    @map("stock_min_plants")
 
   @@unique([userId, varieteId])
   @@index([userId])
@@ -3424,6 +3427,8 @@ model UserStockFertilisant {
   prix          Float?      @map("prix") // €/kg (prix per-user, déprécié, voir coutUnitaire)
   // DEV2 #6
   coutUnitaire  Float?      @map("cout_unitaire")
+  // Seuil minimum d'alerte (réapprovisionnement conseillé)
+  stockMin      Float?      @map("stock_min")
 
   @@unique([userId, fertilisantId])
   @@index([userId])

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,21 @@
+/**
+ * Hameçon de démarrage serveur Next.js (instrumentation, stable depuis
+ * Next 15). `register()` est appelé une fois à l'init du serveur Node —
+ * c'est le point d'attache durable du cron de notifications : il survit
+ * aux redémarrages (re-registré à chaque boot) et ne dépend d'aucune
+ * requête entrante.
+ *
+ * Le module est importé dynamiquement et tout est encapsulé en try/catch :
+ * un problème de scheduler ne doit jamais empêcher le serveur de démarrer.
+ */
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return
+
+  try {
+    const { initNotifScheduler } = await import("@/lib/notifications/scheduler")
+    initNotifScheduler()
+  } catch (error) {
+    console.error("[notifications] Échec d'initialisation du scheduler:", error)
+  }
+}

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -4,6 +4,15 @@
 
 import nodemailer from "nodemailer"
 
+/**
+ * URL publique de l'instance (dérivée de NEXTAUTH_URL, bascule propre en
+ * auto-hébergement). Utilisée pour les liens d'activation / reset de mot de
+ * passe. Sans NEXTAUTH_URL, on retombe sur l'hôte public historique.
+ */
+const APP_URL = (process.env.NEXTAUTH_URL || "https://gleba.fr").replace(/\/$/, "")
+
+export { APP_URL }
+
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: Number(process.env.SMTP_PORT) || 587,
@@ -118,7 +127,7 @@ export function newUserNotificationEmail(user: { email: string; name?: string | 
 
 export function verifyEmailEmail(name: string | null, token: string) {
   const displayName = name || "nouveau membre"
-  const verifyUrl = `https://gleba.fr/api/auth/verify?token=${token}`
+  const verifyUrl = `${APP_URL}/api/auth/verify?token=${token}`
   return {
     subject: "Gleba — Confirmez votre adresse email",
     html: `<!DOCTYPE html>
@@ -291,7 +300,7 @@ export function commandeBoutiqueEmail(args: CommandeBoutiqueEmailArgs) {
 
 export function passwordResetEmail(name: string | null, token: string) {
   const displayName = name || "utilisateur"
-  const resetUrl = `https://gleba.fr/reset-password?token=${token}`
+  const resetUrl = `${APP_URL}/reset-password?token=${token}`
   return {
     subject: "Gleba — Réinitialisation de votre mot de passe",
     html: `<!DOCTYPE html>

--- a/src/lib/notifications/config.ts
+++ b/src/lib/notifications/config.ts
@@ -1,0 +1,33 @@
+/**
+ * Configuration du scheduler de notifications — PUR, sans aucune dépendance
+ * runtime (testable directement, contrairement à scheduler.ts qui tire
+ * nodemailer/prisma via sender.ts).
+ */
+
+/** Parse « HH:MM » → { hour, minute } ou null si invalide. */
+export function parseHeureResume(value: string | undefined): { hour: number; minute: number } | null {
+  if (!value) return null
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim())
+  if (!match) return null
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (hour > 23 || minute > 59) return null
+  return { hour, minute }
+}
+
+/** Expression cron du résumé quotidien (défaut 07:00). */
+export function getResumeCronExpression(
+  env: Record<string, string | undefined> = process.env
+): string {
+  const heure = parseHeureResume(env.NOTIF_RESUME_HEURE) ?? { hour: 7, minute: 0 }
+  return `${heure.minute} ${heure.hour} * * *`
+}
+
+/** Intervalle (minutes) du scan météo — défaut 30, borné [5, 1440]. */
+export function getMeteoIntervalMinutes(
+  env: Record<string, string | undefined> = process.env
+): number {
+  const raw = Number.parseInt(env.NOTIF_METEO_INTERVAL_MIN ?? "30", 10)
+  if (!Number.isInteger(raw)) return 30
+  return Math.min(Math.max(raw, 5), 1440)
+}

--- a/src/lib/notifications/detect.test.ts
+++ b/src/lib/notifications/detect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+import { deciderIrrigationInutile, detecterAlertesMeteo } from "./detect"
+import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
+
+function jour(overrides: Partial<MeteoPrevision> & { date: string }): MeteoPrevision {
+  return {
+    tempMin: 10,
+    tempMax: 20,
+    tempMoy: 15,
+    precipitation: 0,
+    precipitationProba: 0,
+    et0: 2,
+    radiation: 20,
+    sunshine: 6,
+    humidityMin: 50,
+    humidityMax: 80,
+    windSpeedMax: 10,
+    ...overrides,
+  }
+}
+
+describe("detecterAlertesMeteo", () => {
+  it("signale un gel (tempMin <= 0), danger si sévère", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", tempMin: -2 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("gel")
+    expect(alertes[0].niveau).toBe("attention")
+    expect(alertes[0].key).toBe("gel:2026-08-10")
+
+    const severes = detecterAlertesMeteo([jour({ date: "2026-08-11", tempMin: -4 })])
+    expect(severes[0].niveau).toBe("danger")
+  })
+
+  it("signale une canicule (tempMax >= 35), danger si >= 40", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", tempMax: 36 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("canicule")
+    expect(alertes[0].niveau).toBe("attention")
+
+    const severes = detecterAlertesMeteo([jour({ date: "2026-08-11", tempMax: 41 })])
+    expect(severes[0].niveau).toBe("danger")
+  })
+
+  it("signale un vent fort (>= 50 km/h)", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", windSpeedMax: 55 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("vent")
+  })
+
+  it("ne signale pas un vent modéré (ex. 25 km/h)", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", windSpeedMax: 25 })])
+    expect(alertes).toHaveLength(0)
+  })
+
+  it("signale une pluie abondante (>= 20 mm)", () => {
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10", precipitation: 22 })])
+    expect(alertes).toHaveLength(1)
+    expect(alertes[0].type).toBe("pluie")
+    expect(alertes[0].niveau).toBe("attention")
+  })
+
+  it("signale un orage à partir du code WMO courant (95/96/99)", () => {
+    const orage: MeteoActuelle = {
+      temperature: 22,
+      humidity: 80,
+      windSpeed: 15,
+      windDirection: 200,
+      precipitation: 2,
+      weatherCode: 95,
+      weatherDescription: "Orage",
+    }
+    const alertes = detecterAlertesMeteo([jour({ date: "2026-08-10" })], orage)
+    expect(alertes.some((a) => a.type === "orage")).toBe(true)
+    expect(alertes.find((a) => a.type === "orage")?.niveau).toBe("attention")
+
+    const grele: MeteoActuelle = { ...orage, weatherCode: 99, weatherDescription: "Orage avec grêle forte" }
+    const avecGrele = detecterAlertesMeteo([jour({ date: "2026-08-10" })], grele)
+    expect(avecGrele.find((a) => a.type === "orage")?.niveau).toBe("danger")
+  })
+
+  it("n'émet aucune alerte par beau temps", () => {
+    const alertes = detecterAlertesMeteo([
+      jour({ date: "2026-08-10", tempMin: 12, tempMax: 24, windSpeedMax: 15, precipitation: 2 }),
+    ])
+    expect(alertes).toHaveLength(0)
+  })
+
+  it("respecte l'horizon demandé (pas d'alerte au-delà)", () => {
+    const previsions = [
+      jour({ date: "2026-08-10", tempMax: 20 }),
+      jour({ date: "2026-08-11", tempMax: 38 }),
+      jour({ date: "2026-08-12", tempMax: 38 }),
+    ]
+    const alertes = detecterAlertesMeteo(previsions, null, { horizonJours: 2 })
+    expect(alertes.filter((a) => a.type === "canicule")).toHaveLength(1)
+    expect(alertes[0].date).toBe("2026-08-11")
+  })
+})
+
+describe("deciderIrrigationInutile", () => {
+  it("inutile si >= 5 mm de pluie prévus le jour J", () => {
+    expect(deciderIrrigationInutile({ pluiePrevue: 6, pluieRecente3j: 0, joursAvant: 0 })).toBe(true)
+  })
+
+  it("inutile si pluie récente >= 5 mm et échéance dans les 3 jours", () => {
+    expect(deciderIrrigationInutile({ pluiePrevue: null, pluieRecente3j: 12, joursAvant: 1 })).toBe(true)
+    // Échéance plus lointaine → la pluie récente ne couvre plus
+    expect(deciderIrrigationInutile({ pluiePrevue: null, pluieRecente3j: 12, joursAvant: 5 })).toBe(false)
+  })
+
+  it("nécessaire si ni pluie prévue ni pluie récente", () => {
+    expect(deciderIrrigationInutile({ pluiePrevue: 1, pluieRecente3j: 2, joursAvant: 0 })).toBe(false)
+    expect(deciderIrrigationInutile({ pluiePrevue: null, pluieRecente3j: 0, joursAvant: 0 })).toBe(false)
+  })
+})

--- a/src/lib/notifications/detect.test.ts
+++ b/src/lib/notifications/detect.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest"
 import {
   deciderIrrigationInutile,
   detecterAlertesMeteo,
+  detecterStocksAlimentsBas,
+  detecterStocksFertilisantsBas,
+  detecterStocksVarietesBas,
   formaterTemporaliteAlerte,
   indicationHoraireAlerte,
 } from "./detect"
@@ -130,6 +133,66 @@ describe("indicationHoraireAlerte", () => {
     expect(indicationHoraireAlerte("vent")).toMatch(/l'après-midi/)
     expect(indicationHoraireAlerte("pluie")).toMatch(/journée/)
     expect(indicationHoraireAlerte("orage")).toMatch(/proximité immédiate/)
+  })
+})
+
+describe("détection des stocks bas", () => {
+  it("détecte les graines et plants sous leur seuil, y compris un stock nul", () => {
+    const stocks = detecterStocksVarietesBas([
+      {
+        id: 1,
+        varieteId: "carotte",
+        varieteNom: "Carotte nantaise",
+        stockGraines: 40,
+        stockPlants: 0,
+        stockMinGraines: 100,
+        stockMinPlants: 5,
+        uniteStock: "g",
+      },
+    ])
+
+    expect(stocks).toHaveLength(2)
+    expect(stocks.map((stock) => stock.ratio)).toEqual([0, 0.4])
+    expect(stocks[0].quantite).toBe(0)
+  })
+
+  it("ignore une quantité égale ou supérieure au seuil et un seuil nul ou absent", () => {
+    const stocks = detecterStocksVarietesBas([
+      {
+        id: 1,
+        varieteId: "tomate",
+        varieteNom: "Tomate",
+        stockGraines: 100,
+        stockPlants: 10,
+        stockMinGraines: 100,
+        stockMinPlants: 0,
+        uniteStock: null,
+      },
+      {
+        id: 2,
+        varieteId: "laitue",
+        varieteNom: "Laitue",
+        stockGraines: 0,
+        stockPlants: null,
+        stockMinGraines: null,
+        stockMinPlants: null,
+        uniteStock: null,
+      },
+    ])
+
+    expect(stocks).toEqual([])
+  })
+
+  it("détecte les fertilisants et aliments sous seuil", () => {
+    const fertilisants = detecterStocksFertilisantsBas([
+      { id: 1, fertilisantId: "compost", fertilisantNom: "compost", stock: 2, stockMin: 5 },
+    ])
+    const aliments = detecterStocksAlimentsBas([
+      { id: 2, alimentId: "foin", alimentNom: "Foin", stock: 4, stockMin: 10 },
+    ])
+
+    expect(fertilisants[0].ratio).toBe(0.4)
+    expect(aliments[0].ratio).toBe(0.4)
   })
 })
 

--- a/src/lib/notifications/detect.test.ts
+++ b/src/lib/notifications/detect.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { deciderIrrigationInutile, detecterAlertesMeteo } from "./detect"
+import {
+  deciderIrrigationInutile,
+  detecterAlertesMeteo,
+  formaterTemporaliteAlerte,
+  indicationHoraireAlerte,
+} from "./detect"
 import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
 
 function jour(overrides: Partial<MeteoPrevision> & { date: string }): MeteoPrevision {
@@ -94,6 +99,37 @@ describe("detecterAlertesMeteo", () => {
     const alertes = detecterAlertesMeteo(previsions, null, { horizonJours: 2 })
     expect(alertes.filter((a) => a.type === "canicule")).toHaveLength(1)
     expect(alertes[0].date).toBe("2026-08-11")
+  })
+})
+
+describe("formaterTemporaliteAlerte", () => {
+  // Jeudi 13 août 2026 — référence fixe pour des tests déterministes.
+  const reference = new Date(2026, 7, 13)
+
+  it("indique « Aujourd'hui » avec le jour et la date en français", () => {
+    expect(formaterTemporaliteAlerte("2026-08-13", reference)).toBe("Aujourd'hui (jeudi 13 août)")
+  })
+
+  it("indique « Demain » pour le lendemain", () => {
+    expect(formaterTemporaliteAlerte("2026-08-14", reference)).toBe("Demain (vendredi 14 août)")
+  })
+
+  it("indique « le <jour> » au-delà de J+1", () => {
+    expect(formaterTemporaliteAlerte("2026-08-15", reference)).toBe("le samedi 15 août")
+  })
+
+  it("retourne la date brute si le format est invalide", () => {
+    expect(formaterTemporaliteAlerte("invalide", reference)).toBe("invalide")
+  })
+})
+
+describe("indicationHoraireAlerte", () => {
+  it("fournit une indication de moment pour chaque type d'alerte", () => {
+    expect(indicationHoraireAlerte("gel")).toMatch(/fin de nuit/)
+    expect(indicationHoraireAlerte("canicule")).toMatch(/début d'après-midi/)
+    expect(indicationHoraireAlerte("vent")).toMatch(/l'après-midi/)
+    expect(indicationHoraireAlerte("pluie")).toMatch(/journée/)
+    expect(indicationHoraireAlerte("orage")).toMatch(/proximité immédiate/)
   })
 })
 

--- a/src/lib/notifications/detect.ts
+++ b/src/lib/notifications/detect.ts
@@ -320,3 +320,167 @@ export function calculerRecoltesMures(
 
   return mures.sort((a, b) => a.joursRestants - b.joursRestants)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stocks bas (issue #16) — détection pure
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Entrée de stock variété pour la détection. */
+export interface StockVarieteInput {
+  id: number
+  varieteId: string
+  varieteNom: string
+  stockGraines: number | null
+  stockPlants: number | null
+  stockMinGraines: number | null
+  stockMinPlants: number | null
+  uniteStock: string | null
+}
+
+/** Entrée de stock fertilisant pour la détection. */
+export interface StockFertilisantInput {
+  id: number
+  fertilisantId: string
+  fertilisantNom: string
+  stock: number | null
+  stockMin: number | null
+}
+
+/** Entrée de stock aliment pour la détection. */
+export interface StockAlimentInput {
+  id: number
+  alimentId: string
+  alimentNom: string
+  stock: number | null
+  stockMin: number | null
+}
+
+/** Stock bas détecté (structure interne pour la détection pure). */
+export interface StockBasDetecte {
+  type: "variete" | "fertilisant" | "aliment"
+  stockId: number
+  nom: string
+  unite: string
+  quantite: number
+  seuilMin: number
+  ratio: number // quantite / seuilMin
+  localisation?: string
+  /** Clé stable : `stock-bas:<type>:<stockId>:<seuilMin>` */
+  key: string
+}
+
+/**
+ * Détecte les stocks de variétés passés sous leur seuil minimum.
+ * Ne considère que les stocks ayant un seuil défini (stockMinGraines ou stockMinPlants > 0)
+ * et une quantité actuelle strictement inférieure au seuil.
+ */
+export function detecterStocksVarietesBas(
+  stocks: StockVarieteInput[]
+): StockBasDetecte[] {
+  const bas: StockBasDetecte[] = []
+  for (const stock of stocks) {
+    // Graines
+    if (stock.stockMinGraines != null && stock.stockMinGraines > 0 && stock.stockGraines != null) {
+      if (stock.stockGraines < stock.stockMinGraines) {
+        const unite = stock.uniteStock || "g"
+        bas.push({
+          type: "variete",
+          stockId: stock.id,
+          nom: stock.varieteNom,
+          unite,
+          quantite: stock.stockGraines,
+          seuilMin: stock.stockMinGraines,
+          ratio: stock.stockGraines / stock.stockMinGraines,
+          key: `stock-bas:variete:${stock.id}:${stock.stockMinGraines}:graines`,
+        })
+      }
+    }
+    // Plants
+    if (stock.stockMinPlants != null && stock.stockMinPlants > 0 && stock.stockPlants != null) {
+      if (stock.stockPlants < stock.stockMinPlants) {
+        const unite = stock.uniteStock === "plants" || stock.uniteStock === "pieces" ? "plants" : "plants"
+        bas.push({
+          type: "variete",
+          stockId: stock.id,
+          nom: stock.varieteNom,
+          unite: "plants",
+          quantite: stock.stockPlants,
+          seuilMin: stock.stockMinPlants,
+          ratio: stock.stockPlants / stock.stockMinPlants,
+          key: `stock-bas:variete:${stock.id}:${stock.stockMinPlants}:plants`,
+        })
+      }
+    }
+  }
+  return bas.sort((a, b) => a.ratio - b.ratio) // les plus critiques d'abord
+}
+
+/**
+ * Détecte les stocks de fertilisants passés sous leur seuil minimum.
+ */
+export function detecterStocksFertilisantsBas(
+  stocks: StockFertilisantInput[]
+): StockBasDetecte[] {
+  const bas: StockBasDetecte[] = []
+  for (const stock of stocks) {
+    if (stock.stockMin != null && stock.stockMin > 0 && stock.stock != null) {
+      if (stock.stock < stock.stockMin) {
+        bas.push({
+          type: "fertilisant",
+          stockId: stock.id,
+          nom: stock.fertilisantNom,
+          unite: "kg/L",
+          quantite: stock.stock,
+          seuilMin: stock.stockMin,
+          ratio: stock.stock / stock.stockMin,
+          key: `stock-bas:fertilisant:${stock.id}:${stock.stockMin}`,
+        })
+      }
+    }
+  }
+  return bas.sort((a, b) => a.ratio - b.ratio)
+}
+
+/**
+ * Détecte les stocks d'aliments passés sous leur seuil minimum.
+ */
+export function detecterStocksAlimentsBas(
+  stocks: StockAlimentInput[]
+): StockBasDetecte[] {
+  const bas: StockBasDetecte[] = []
+  for (const stock of stocks) {
+    if (stock.stockMin != null && stock.stockMin > 0 && stock.stock != null) {
+      if (stock.stock < stock.stockMin) {
+        bas.push({
+          type: "aliment",
+          stockId: stock.id,
+          nom: stock.alimentNom,
+          unite: "kg",
+          quantite: stock.stock,
+          seuilMin: stock.stockMin,
+          ratio: stock.stock / stock.stockMin,
+          key: `stock-bas:aliment:${stock.id}:${stock.stockMin}`,
+        })
+      }
+    }
+  }
+  return bas.sort((a, b) => a.ratio - b.ratio)
+}
+
+/**
+ * Fusionne et trie tous les stocks bas détectés (tous types confondus).
+ * Les plus critiques (ratio le plus bas) en premier.
+ */
+export function fusionnerStocksBas(...listes: StockBasDetecte[][]): StockBasDetecte[] {
+  const tous = listes.flat()
+  return tous.sort((a, b) => a.ratio - b.ratio)
+}
+
+/**
+ * Formate un stock bas pour l'affichage dans l'email/résumé.
+ */
+export function formaterStockBas(stock: StockBasDetecte): string {
+  const pct = Math.round(stock.ratio * 100)
+  return `${stock.nom} : ${stock.quantite} ${stock.unite} (seuil ${stock.seuilMin} ${stock.unite}, ${pct}%)`
+}
+

--- a/src/lib/notifications/detect.ts
+++ b/src/lib/notifications/detect.ts
@@ -15,6 +15,7 @@
  */
 
 import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
+import { DUREE_CULTURE_DEFAUT } from "@/lib/plan-croissance"
 import type { AlerteMeteoNotification, TypeAlerteMeteo } from "./types"
 
 export const SEUILS_METEO = {
@@ -216,4 +217,106 @@ export function indicationHoraireAlerte(type: TypeAlerteMeteo): string {
     case "orage":
       return "Orage possible à proximité immédiate."
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Récoltes mûres (issue #16) — maturité calculée depuis le début du cycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fenêtre de déclenchement d'une alerte « récolte mûre » : on prévient à
+ * J-3 avant la maturité calculée (date semis/plantation + durée culture ITP).
+ */
+export const FENETRE_RECOLTE_MURE_AVANCE_JOURS = 3
+
+/**
+ * Tolérance de dépassement après la maturité (scans manqués, week-end).
+ * Au-delà, la culture est soit déjà récoltée, soit oubliée — pas de spam.
+ */
+export const FENETRE_RECOLTE_MURE_DEPASSEMENT_JOURS = 2
+
+/** Durée de culture (jours) par défaut quand l'ITP de la culture ne la donne pas. */
+export const DUREE_CULTURE_FALLBACK_JOURS = DUREE_CULTURE_DEFAUT
+
+const JOUR_MS = 86_400_000
+
+/** Culture potentiellement mûre (données déjà jointes depuis la base). */
+export interface CultureRecolteInput {
+  id: number
+  dateSemis: Date | string | null
+  datePlantation: Date | string | null
+  /** true → culture déjà récoltée : jamais notifiable. */
+  recolteFaite: boolean
+  /** Durée de culture en jours de l'ITP rattaché (null → DUREE_CULTURE_FALLBACK_JOURS). */
+  dureeCultureJours: number | null
+  especeNom: string
+  plancheNom: string | null
+}
+
+/** Culture détectée comme mûre ou imminente. */
+export interface RecolteMure {
+  cultureId: number
+  especeNom: string
+  plancheNom: string | null
+  /** Date de maturité calculée (YYYY-MM-DD, fuseau local). */
+  dateMaturite: string
+  /** Jours restants avant maturité (0 = aujourd'hui, négatif = déjà dépassée). */
+  joursRestants: number
+  /** Durée de culture utilisée pour le calcul (jours). */
+  dureeJours: number
+}
+
+function debutJour(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+/**
+ * Calcule, parmi des cultures actives, celles dont la maturité est atteinte
+ * ou imminente. Maturité = date de mise en place (plantation préférée au
+ * semis) + durée de culture (ITP de la culture, sinon défaut 90 j).
+ *
+ * Fenêtre par défaut : [J-3 avant maturité … J+2 après] — voir constantes.
+ * Les cultures déjà récoltées sont exclues ; le résultat est trié des plus
+ * urgentes aux moins urgentes.
+ *
+ * Fonction PURE : testable sans Prisma (utilisée par queries.ts pour les
+ * alertes temps réel ET le résumé quotidien).
+ */
+export function calculerRecoltesMures(
+  cultures: CultureRecolteInput[],
+  aujourdHui: Date = new Date(),
+  options: { avanceJours?: number; depassementJours?: number; dureeDefautJours?: number } = {}
+): RecolteMure[] {
+  const avance = options.avanceJours ?? FENETRE_RECOLTE_MURE_AVANCE_JOURS
+  const depassement = options.depassementJours ?? FENETRE_RECOLTE_MURE_DEPASSEMENT_JOURS
+  const dureeDefaut = options.dureeDefautJours ?? DUREE_CULTURE_FALLBACK_JOURS
+
+  const reference = debutJour(aujourdHui).getTime()
+  const mures: RecolteMure[] = []
+
+  for (const culture of cultures) {
+    if (culture.recolteFaite) continue
+    const debut = culture.datePlantation ?? culture.dateSemis
+    if (!debut) continue
+    const debutDate = debut instanceof Date ? debut : new Date(debut)
+    if (Number.isNaN(debutDate.getTime())) continue
+
+    const dureeJours = culture.dureeCultureJours ?? dureeDefaut
+    if (!Number.isFinite(dureeJours) || dureeJours <= 0) continue
+
+    const maturite = new Date(debutDate.getTime() + dureeJours * JOUR_MS)
+    const joursRestants = Math.round((debutJour(maturite).getTime() - reference) / JOUR_MS)
+    if (joursRestants > avance || joursRestants < -depassement) continue
+
+    mures.push({
+      cultureId: culture.id,
+      especeNom: culture.especeNom,
+      plancheNom: culture.plancheNom,
+      dateMaturite: dateLocaleIso(maturite),
+      joursRestants,
+      dureeJours,
+    })
+  }
+
+  return mures.sort((a, b) => a.joursRestants - b.joursRestants)
 }

--- a/src/lib/notifications/detect.ts
+++ b/src/lib/notifications/detect.ts
@@ -1,0 +1,176 @@
+/**
+ * Détection PURE des conditions à risque (météo + irrigation).
+ *
+ * Consomme les données déjà fetchées par `@/lib/meteo` (fetchOpenMeteoForecast,
+ * fetchOpenMeteoHistory) — aucune duplication des appels API ici.
+ *
+ * Seuils calibrés pour des NOTIFICATIONS par email (donc volontairement plus
+ * exigeants que les alertes in-app de `meteo-agro.genererAlertesMeteo` :
+ * un email pour 19 km/h de vent serait du spam) :
+ *   - gel         : tempMin <= 0 °C
+ *   - canicule    : tempMax >= 35 °C
+ *   - vent fort   : windSpeedMax >= 50 km/h
+ *   - pluie abondante : precipitation >= 20 mm/jour
+ *   - orage       : code WMO courant 95/96/99 (orage, grêle)
+ */
+
+import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
+import type { AlerteMeteoNotification } from "./types"
+
+export const SEUILS_METEO = {
+  gel: { tempMin: 0, danger: -3 },
+  canicule: { tempMax: 35, danger: 40 },
+  ventFort: { vitesse: 50, danger: 70 },
+  pluieAbondante: { mm: 20, danger: 40 },
+  codesOrage: [95, 96, 99] as readonly number[],
+} as const
+
+/** Code WMO d'un orage avec grêle (danger). */
+const CODES_GRÊLE = [96, 99]
+
+function todayIso(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+    now.getDate()
+  ).padStart(2, "0")}`
+}
+
+/**
+ * Détecte les alertes météo notifiables sur l'horizon demandé (défaut : tous
+ * les jours de la prévision). En temps réel on limite à 48 h ; le résumé du
+ * matin utilise la journée courante.
+ */
+export function detecterAlertesMeteo(
+  previsions: MeteoPrevision[],
+  current: MeteoActuelle | null = null,
+  options: { horizonJours?: number } = {}
+): AlerteMeteoNotification[] {
+  const horizon = options.horizonJours ?? previsions.length
+  const alertes: AlerteMeteoNotification[] = []
+
+  for (let i = 0; i < Math.min(horizon, previsions.length); i++) {
+    const jour = previsions[i]
+    if (!jour) continue
+
+    // ── Gel ──
+    if (jour.tempMin <= SEUILS_METEO.gel.tempMin) {
+      alertes.push({
+        type: "gel",
+        date: jour.date,
+        niveau: jour.tempMin <= SEUILS_METEO.gel.danger ? "danger" : "attention",
+        message: `Risque de gel : ${jour.tempMin}°C prévu`,
+        details:
+          jour.tempMin <= SEUILS_METEO.gel.danger
+            ? "Gel sévère annoncé. Protéger les cultures sensibles (voile d'hivernage, paillage, tunnel). Risque fort pour les semis récents et les arbres en floraison."
+            : "Gel léger possible. Surveiller les cultures non protégées et les semis récents ; un voile de protection peut suffire.",
+        key: `gel:${jour.date}`,
+      })
+    }
+
+    // ── Canicule ──
+    if (jour.tempMax >= SEUILS_METEO.canicule.tempMax) {
+      alertes.push({
+        type: "canicule",
+        date: jour.date,
+        niveau: jour.tempMax >= SEUILS_METEO.canicule.danger ? "danger" : "attention",
+        message: `Canicule : ${jour.tempMax}°C prévu`,
+        details:
+          "Augmenter la fréquence d'irrigation, ombrer les cultures sensibles (salades, épinards). Arroser tôt le matin ou le soir pour limiter l'évaporation.",
+        key: `canicule:${jour.date}`,
+      })
+    }
+
+    // ── Vent fort ──
+    if (jour.windSpeedMax >= SEUILS_METEO.ventFort.vitesse) {
+      alertes.push({
+        type: "vent",
+        date: jour.date,
+        niveau: jour.windSpeedMax >= SEUILS_METEO.ventFort.danger ? "danger" : "attention",
+        message: `Vent fort : ${Math.round(jour.windSpeedMax)} km/h attendu`,
+        details:
+          "Éviter tout traitement phytosanitaire (interdit au-delà de 19 km/h). Brise-vent et tuteurage à vérifier ; reporter les semis en plein vent si possible.",
+        key: `vent:${jour.date}`,
+      })
+    }
+
+    // ── Pluie abondante ──
+    if (jour.precipitation >= SEUILS_METEO.pluieAbondante.mm) {
+      alertes.push({
+        type: "pluie",
+        date: jour.date,
+        niveau: jour.precipitation >= SEUILS_METEO.pluieAbondante.danger ? "danger" : "attention",
+        message: `Pluie abondante : ${jour.precipitation} mm prévus`,
+        details:
+          "Reporter les semis et plantations si possible ; surveiller l'engorgement des planches et la sensibilité des jeunes plants. L'irrigation des prochains jours sera probablement inutile.",
+        key: `pluie:${jour.date}`,
+      })
+    }
+  }
+
+  // ── Orage (conditions actuelles, code WMO) ──
+  if (current && SEUILS_METEO.codesOrage.includes(current.weatherCode)) {
+    const avecGrêle = CODES_GRÊLE.includes(current.weatherCode)
+    alertes.push({
+      type: "orage",
+      date: todayIso(),
+      niveau: avecGrêle ? "danger" : "attention",
+      message: `Orage${avecGrêle ? " avec grêle" : ""} en cours : ${current.weatherDescription}`,
+      details: avecGrêle
+        ? "Risque de grêle : mettre à l'abri les plants les plus précieux, fermer les tunnels. Débrancher les équipements électriques sensibles."
+        : "Orage à proximité : couvrir les semis sensibles si possible ; rester attentif aux rafales.",
+      key: `orage:${todayIso()}`,
+    })
+  }
+
+  return alertes
+}
+
+export const SEUILS_IRRIGATION_INUTILE = {
+  pluiePrevue: 5, // mm prévus le jour J → irrigation inutile
+  pluieRecente: 5, // mm cumulés sur 3 j
+  joursCouverture: 3,
+} as const
+
+/**
+ * Décide si une irrigation planifiée est probablement inutile (même heuristique
+ * que la route /api/calendrier, factorisée pour être testable et réutilisée
+ * par les alertes temps réel).
+ */
+export function deciderIrrigationInutile(opts: {
+  pluiePrevue: number | null
+  pluieRecente3j: number
+  joursAvant: number
+}): boolean {
+  const { pluiePrevue, pluieRecente3j, joursAvant } = opts
+  const inutileParPluieRecente =
+    pluieRecente3j >= SEUILS_IRRIGATION_INUTILE.pluieRecente &&
+    joursAvant <= SEUILS_IRRIGATION_INUTILE.joursCouverture
+  const inutileParPrevision =
+    pluiePrevue !== null && pluiePrevue >= SEUILS_IRRIGATION_INUTILE.pluiePrevue
+  return inutileParPluieRecente || inutileParPrevision
+}
+
+/** Date locale du serveur (fuseau TZ, ex. Europe/Paris) au format YYYY-MM-DD. */
+export function dateLocaleIso(date: Date = new Date()): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+/** Début de journée locale (minuit) sous forme de Date. */
+export function debutDeJournee(date: Date = new Date()): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+/** Fin de journée locale (minuit + 1 jour). */
+export function finDeJournee(date: Date = new Date()): Date {
+  const start = debutDeJournee(date)
+  return new Date(start.getFullYear(), start.getMonth(), start.getDate() + 1)
+}
+
+export function formatDateFr(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number)
+  if (!y || !m || !d) return iso
+  return `${String(d).padStart(2, "0")}/${String(m).padStart(2, "0")}/${y}`
+}

--- a/src/lib/notifications/detect.ts
+++ b/src/lib/notifications/detect.ts
@@ -15,7 +15,7 @@
  */
 
 import type { MeteoActuelle, MeteoPrevision } from "@/lib/meteo"
-import type { AlerteMeteoNotification } from "./types"
+import type { AlerteMeteoNotification, TypeAlerteMeteo } from "./types"
 
 export const SEUILS_METEO = {
   gel: { tempMin: 0, danger: -3 },
@@ -173,4 +173,47 @@ export function formatDateFr(iso: string): string {
   const [y, m, d] = iso.split("-").map(Number)
   if (!y || !m || !d) return iso
   return `${String(d).padStart(2, "0")}/${String(m).padStart(2, "0")}/${y}`
+}
+
+/** Jour de la semaine + date en français (ex. « jeudi 13 août »). */
+const FORMATTEUR_DATE_LONGUE = new Intl.DateTimeFormat("fr-FR", {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+})
+
+/**
+ * Temporalité lisible d'une alerte météo pour le corps de l'email :
+ *   - « Aujourd'hui (jeudi 13 août) » si la date est le jour courant,
+ *   - « Demain (vendredi 14 août) » si c'est le lendemain,
+ *   - « le samedi 15 août » sinon.
+ * `reference` ne sert qu'aux tests (rend la fonction déterministe).
+ */
+export function formaterTemporaliteAlerte(dateIso: string, reference: Date = new Date()): string {
+  const [y, m, d] = dateIso.split("-").map(Number)
+  if (!y || !m || !d) return dateIso
+  const date = new Date(y, m - 1, d)
+  const diffJours = Math.round(
+    (debutDeJournee(date).getTime() - debutDeJournee(reference).getTime()) / 86400000
+  )
+  const label = FORMATTEUR_DATE_LONGUE.format(date)
+  if (diffJours === 0) return `Aujourd'hui (${label})`
+  if (diffJours === 1) return `Demain (${label})`
+  return `le ${label}`
+}
+
+/** Indication informative du moment de la journée concerné (petite ligne de l'email). */
+export function indicationHoraireAlerte(type: TypeAlerteMeteo): string {
+  switch (type) {
+    case "gel":
+      return "Risque de gel en fin de nuit / au lever du jour."
+    case "canicule":
+      return "Température maximale attendue en début d'après-midi."
+    case "vent":
+      return "Rafales les plus fortes attendues l'après-midi."
+    case "pluie":
+      return "Précipitations concentrées sur la journée."
+    case "orage":
+      return "Orage possible à proximité immédiate."
+  }
 }

--- a/src/lib/notifications/itp-semaine.test.ts
+++ b/src/lib/notifications/itp-semaine.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest"
+import {
+  operationsItp,
+  operationsItpDansSemaine,
+  semaineCourante,
+  tachesItpSemainePourCultures,
+} from "./itp-semaine"
+import type { CultureItpInput, ItpSemaineInput } from "./itp-semaine"
+
+// Référence fixe : mardi 11 août 2026 → semaine ISO 33 (lundi 10 → dimanche 16).
+const REFERENCE = new Date(2026, 7, 11)
+
+function itp(overrides: Partial<ItpSemaineInput> = {}): ItpSemaineInput {
+  return {
+    id: "ITP-Test",
+    zoneClimat: null,
+    semaineSemis: null,
+    semainePlantation: null,
+    semaineRecolte: null,
+    semaineRecolteFin: null,
+    dureeRecolte: null,
+    ...overrides,
+  }
+}
+
+function culture(overrides: Partial<CultureItpInput> = {}): CultureItpInput {
+  return {
+    id: 1,
+    especeId: "Tomate",
+    annee: 2026,
+    semisFait: false,
+    plantationFaite: false,
+    recolteFaite: false,
+    couleur: "#dc2626",
+    especeNom: "Tomate",
+    varieteNom: null,
+    plancheName: "S1",
+    ilot: "A",
+    itp: itp({ semaineRecolte: 33 }),
+    ...overrides,
+  }
+}
+
+describe("semaineCourante", () => {
+  it("calcule la semaine ISO 33 du 11 août 2026 (lundi → dimanche)", () => {
+    const s = semaineCourante(REFERENCE)
+    expect(s.annee).toBe(2026)
+    expect(s.semaine).toBe(33)
+    expect(s.debutIso).toBe("2026-08-10")
+    expect(s.finIso).toBe("2026-08-16")
+  })
+
+  it("garde les mêmes bornes du lundi au dimanche", () => {
+    const lundi = semaineCourante(new Date(2026, 7, 10))
+    const dimanche = semaineCourante(new Date(2026, 7, 16))
+    const mardi = semaineCourante(REFERENCE)
+    expect(lundi).toEqual(dimanche)
+    expect(lundi).toEqual(mardi)
+  })
+
+  it("bascule en semaine 34 le lundi suivant", () => {
+    const s = semaineCourante(new Date(2026, 7, 17))
+    expect(s.semaine).toBe(34)
+    expect(s.debutIso).toBe("2026-08-17")
+    expect(s.finIso).toBe("2026-08-23")
+  })
+
+  it("gère le chevauchement de fin d'année (31 déc. 2026 = semaine 1 de 2026)", () => {
+    const s = semaineCourante(new Date(2026, 11, 31))
+    expect(s.semaine).toBe(1)
+    expect(s.annee).toBe(2026)
+    expect(s.debutIso).toBe("2026-12-28")
+    expect(s.finIso).toBe("2027-01-03")
+  })
+
+  it("gère la bascule d'année ISO (4 janv. 2027 = semaine 2 de 2027)", () => {
+    const s = semaineCourante(new Date(2027, 0, 4))
+    expect(s.semaine).toBe(2)
+    expect(s.annee).toBe(2027)
+    expect(s.debutIso).toBe("2027-01-04")
+  })
+})
+
+describe("operationsItp", () => {
+  it("positionne le semis sur le lundi de sa semaine ISO", () => {
+    const ops = operationsItp(itp({ semaineSemis: 33 }), { anneeCulture: 2026 })
+    expect(ops).toHaveLength(1)
+    expect(ops[0].type).toBe("semis")
+    expect(ops[0].debut).toEqual(new Date(2026, 7, 10))
+  })
+
+  it("rejette la plantation postérieure au semis sur l'année suivante", () => {
+    // Semis S31 (début août), plantation S3 → l'année suivante (janvier).
+    const ops = operationsItp(itp({ semaineSemis: 31, semainePlantation: 3 }), {
+      anneeCulture: 2026,
+    })
+    const plantation = ops.find((o) => o.type === "plantation")
+    expect(plantation?.debut).toEqual(new Date(2027, 0, 11))
+  })
+
+  it("étale la récolte sur la fenêtre [début, fin]", () => {
+    const ops = operationsItp(itp({ semaineRecolte: 33, semaineRecolteFin: 35 }), {
+      anneeCulture: 2026,
+    })
+    const recolte = ops.find((o) => o.type === "recolte")
+    expect(recolte?.debut).toEqual(new Date(2026, 7, 10))
+    expect(recolte?.fin).toEqual(new Date(2026, 7, 30)) // dimanche S35
+  })
+
+  it("utilise dureeRecolte comme repli de la fenêtre", () => {
+    const ops = operationsItp(itp({ semaineRecolte: 33, dureeRecolte: 3 }), {
+      anneeCulture: 2026,
+    })
+    const recolte = ops.find((o) => o.type === "recolte")
+    expect(recolte?.fin).toEqual(new Date(2026, 7, 30))
+  })
+
+  it("applique le décalage de zone aux semaines", () => {
+    const ops = operationsItp(itp({ semaineRecolte: 35 }), {
+      anneeCulture: 2026,
+      decalageZone: -2, // méditerranéen : 2 semaines plus précoce
+    })
+    const recolte = ops.find((o) => o.type === "recolte")
+    expect(recolte?.debut).toEqual(new Date(2026, 7, 10)) // S33
+  })
+})
+
+describe("operationsItpDansSemaine", () => {
+  const cible = semaineCourante(REFERENCE) // S33 2026
+
+  it("retient l'opération dont la semaine tombe dans la fenêtre cible", () => {
+    const ops = operationsItpDansSemaine(itp({ semaineSemis: 33 }), cible, { anneeCulture: 2026 })
+    expect(ops).toHaveLength(1)
+    expect(ops[0].type).toBe("semis")
+    expect(ops[0].date).toBe("2026-08-10")
+  })
+
+  it("exclut les opérations hors fenêtre (semaine précédente et suivante)", () => {
+    const avant = operationsItpDansSemaine(itp({ semaineSemis: 32 }), cible, { anneeCulture: 2026 })
+    const apres = operationsItpDansSemaine(itp({ semaineSemis: 34 }), cible, { anneeCulture: 2026 })
+    expect(avant).toHaveLength(0)
+    expect(apres).toHaveLength(0)
+  })
+
+  it("retient la récolte dont la fenêtre couvre la semaine cible", () => {
+    // Fenêtre S32→S34 : la semaine 33 est dedans.
+    const ops = operationsItpDansSemaine(
+      itp({ semaineRecolte: 32, semaineRecolteFin: 34 }),
+      cible,
+      { anneeCulture: 2026 }
+    )
+    expect(ops).toHaveLength(1)
+    expect(ops[0].type).toBe("recolte")
+  })
+
+  it("exclut une fenêtre de récolte qui ne touche pas la semaine cible", () => {
+    const avant = operationsItpDansSemaine(
+      itp({ semaineRecolte: 29, semaineRecolteFin: 31 }),
+      cible,
+      { anneeCulture: 2026 }
+    )
+    const apres = operationsItpDansSemaine(
+      itp({ semaineRecolte: 35, semaineRecolteFin: 37 }),
+      cible,
+      { anneeCulture: 2026 }
+    )
+    expect(avant).toHaveLength(0)
+    expect(apres).toHaveLength(0)
+  })
+
+  it("retient une récolte d'hiver reportée sur l'année suivante", () => {
+    // Semis S31 (2026), récolte S4 → semaine 4 de 2027.
+    const cibleHiver = semaineCourante(new Date(2027, 0, 18))
+    const ops = operationsItpDansSemaine(itp({ semaineSemis: 31, semaineRecolte: 4 }), cibleHiver, {
+      anneeCulture: 2026,
+    })
+    expect(ops).toHaveLength(1)
+    expect(ops[0].type).toBe("recolte")
+    expect(ops[0].date).toBe("2027-01-18")
+  })
+})
+
+describe("tachesItpSemainePourCultures", () => {
+  it("génère une tâche pour une culture active dont l'ITP a une opération cette semaine", () => {
+    const taches = tachesItpSemainePourCultures([culture()], { aujourdHui: REFERENCE })
+    expect(taches).toHaveLength(1)
+    expect(taches[0]).toMatchObject({
+      cultureId: 1,
+      type: "recolte",
+      especeNom: "Tomate",
+      varieteNom: null,
+      plancheName: "S1",
+      ilot: "A",
+      date: "2026-08-10",
+      semaine: 33,
+      couleur: "#dc2626",
+    })
+  })
+
+  it("ignore les cultures sans ITP", () => {
+    const taches = tachesItpSemainePourCultures([culture({ itp: null })], {
+      aujourdHui: REFERENCE,
+    })
+    expect(taches).toHaveLength(0)
+  })
+
+  it("éteint chaque opération déjà faite (semisFait → plus de semis)", () => {
+    const taches = tachesItpSemainePourCultures(
+      [
+        culture({
+          id: 1,
+          itp: itp({ semaineSemis: 33, semainePlantation: 33 }),
+          semisFait: true,
+          plantationFaite: false,
+        }),
+      ],
+      { aujourdHui: REFERENCE }
+    )
+    expect(taches).toHaveLength(1)
+    expect(taches[0].type).toBe("plantation")
+  })
+
+  it("n'éteint pas une opération d'un autre type", () => {
+    const taches = tachesItpSemainePourCultures(
+      [culture({ itp: itp({ semaineSemis: 33, semaineRecolte: 33 }), recolteFaite: false })],
+      { aujourdHui: REFERENCE }
+    )
+    expect(taches.map((t) => t.type).sort()).toEqual(["recolte", "semis"])
+  })
+
+  it("applique le décalage de la zone de l'utilisateur", () => {
+    // ITP de référence (zoneClimat null, calé océanique altéré) : récolte S35.
+    // Utilisateur méditerranéen (-2 semaines) → récolte effective S33.
+    const taches = tachesItpSemainePourCultures(
+      [culture({ itp: itp({ semaineRecolte: 35 }) })],
+      { userZone: "mediterraneen", aujourdHui: REFERENCE }
+    )
+    expect(taches).toHaveLength(1)
+    expect(taches[0].type).toBe("recolte")
+  })
+
+  it("exclut les ITP métropolitains hors de la métropole (zone tropicale)", () => {
+    const taches = tachesItpSemainePourCultures(
+      [culture({ itp: itp({ semaineRecolte: 33 }) })],
+      { userZone: "tropical_antilles", aujourdHui: REFERENCE }
+    )
+    expect(taches).toHaveLength(0)
+  })
+
+  it("ancre une culture sans année sur l'année de la semaine cible", () => {
+    const taches = tachesItpSemainePourCultures(
+      [culture({ annee: null, itp: itp({ semaineSemis: 33 }) })],
+      { aujourdHui: REFERENCE }
+    )
+    expect(taches).toHaveLength(1)
+    expect(taches[0].date).toBe("2026-08-10")
+  })
+
+  it("trie par date puis par type (semis, plantation, récolte)", () => {
+    const taches = tachesItpSemainePourCultures(
+      [
+        culture({ id: 1, itp: itp({ semaineRecolte: 33 }) }),
+        culture({ id: 2, itp: itp({ semaineSemis: 33, semainePlantation: 33 }) }),
+      ],
+      { aujourdHui: REFERENCE }
+    )
+    expect(taches.map((t) => t.type)).toEqual(["semis", "plantation", "recolte"])
+  })
+
+  it("ne génère rien quand aucune opération ne tombe cette semaine", () => {
+    const taches = tachesItpSemainePourCultures(
+      [
+        culture({ itp: itp({ semaineSemis: 30 }) }),
+        culture({ id: 2, itp: itp({ semaineRecolte: 36 }) }),
+      ],
+      { aujourdHui: REFERENCE }
+    )
+    expect(taches).toHaveLength(0)
+  })
+
+  it("ne génère rien sans aucune culture", () => {
+    expect(tachesItpSemainePourCultures([], { aujourdHui: REFERENCE })).toHaveLength(0)
+  })
+})

--- a/src/lib/notifications/itp-semaine.ts
+++ b/src/lib/notifications/itp-semaine.ts
@@ -1,0 +1,235 @@
+/**
+ * Tâches ITP de la semaine (issue #16) — logique PURE.
+ *
+ * Chaque ITP (itinéraire technique) déclare les semaines canoniques de ses
+ * opérations : `semaineSemis`, `semainePlantation`, `semaineRecolte` (début de
+ * fenêtre), plus une fin de fenêtre de récolte (`semaineRecolteFin`, ou
+ * `dureeRecolte` en repli). On en dérive les opérations « à faire cette
+ * semaine » pour les cultures ACTIVES de l'utilisateur (culture rattachée à un
+ * ITP, ou espèce disposant d'un ITP de référence).
+ *
+ * Choix de fenêtre : la SEMAINE CIVILE lundi → dimanche (semaine ISO), pas 7
+ * jours glissants — c'est la convention du référentiel Gleba (semaines ISO,
+ * `calculerDateDepuisSemaine` calée sur un lundi) et le repère naturel du
+ * maraîcher (« Semer les tomates cette semaine »). Une opération est « dans la
+ * semaine » quand sa fenêtre couvre au moins un jour de la semaine cible.
+ *
+ * Les semaines de l'ITP sont recalées sur la zone climatique de l'exploitation
+ * (mêmes helpers que la planification : `decalageItpPourZone` +
+ * `appliquerDecalageItp`), et l'ancrage se fait sur l'année de la culture
+ * (`Culture.annee`, sinon l'année courante) avec report chronologique des
+ * opérations qui chevauchent l'année suivante (récolte d'hiver d'un semis
+ * d'automne, par ex.).
+ *
+ * Aucun import runtime lourd : testable sans Prisma ni réseau.
+ */
+
+import { addDays, getISOWeekYear, getWeek, startOfWeek } from "date-fns"
+import { calculerDateDepuisSemaine, dateSemaineChrono } from "@/lib/assistant-helpers"
+import {
+  appliquerDecalageItp,
+  decalageItpPourZone,
+  itpApplicableAZone,
+} from "@/lib/calendrier-climat"
+import type { ZoneClimat } from "@/lib/terroir"
+import { dateLocaleIso } from "./detect"
+import type { TacheItpSemaine, TypeOperationItp } from "./types"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Semaine civile courante (lundi → dimanche, semaine ISO)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SemaineCourante {
+  /** Année ISO de la semaine (getISOWeekYear — diffère en début/fin d'année). */
+  annee: number
+  /** Numéro de semaine ISO (1-53). */
+  semaine: number
+  /** Lundi minuit (heure locale). */
+  debut: Date
+  /** Dimanche minuit + 1 jour (exclusif). */
+  fin: Date
+  /** YYYY-MM-DD du lundi. */
+  debutIso: string
+  /** YYYY-MM-DD du dimanche. */
+  finIso: string
+}
+
+/** Semaine civile (ISO) contenant `reference` — défaut : aujourd'hui. */
+export function semaineCourante(reference: Date = new Date()): SemaineCourante {
+  const debut = startOfWeek(reference, { weekStartsOn: 1 })
+  const fin = addDays(debut, 7)
+  return {
+    annee: getISOWeekYear(reference),
+    semaine: getWeek(reference, { weekStartsOn: 1 }),
+    debut,
+    fin,
+    debutIso: dateLocaleIso(debut),
+    finIso: dateLocaleIso(addDays(debut, 6)),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Opérations d'un ITP (semis / plantation / récolte) et leur fenêtre
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Champs d'un ITP utiles au calcul des opérations hebdomadaires. */
+export interface ItpSemaineInput {
+  id: string
+  zoneClimat: ZoneClimat | null
+  semaineSemis?: number | null
+  semainePlantation?: number | null
+  /** Début de la fenêtre de récolte (semaine ISO). */
+  semaineRecolte?: number | null
+  /** Fin de la fenêtre de récolte (semaine ISO) — prioritaire sur dureeRecolte. */
+  semaineRecolteFin?: number | null
+  /** Durée de récolte en semaines (repli si semaineRecolteFin absent). */
+  dureeRecolte?: number | null
+}
+
+/** Fenêtre (en dates) d'une opération ITP. */
+export interface FenetreOperationItp {
+  type: TypeOperationItp
+  /** Lundi de la première semaine de la fenêtre. */
+  debut: Date
+  /** Dimanche (fin de journée) de la dernière semaine de la fenêtre. */
+  fin: Date
+}
+
+const JOUR_MS = 86_400_000
+
+/**
+ * Opérations d'un ITP positionnées sur l'année de la culture, avec décalage
+ * de zone appliqué et report chronologique (plantation/récolte peuvent passer
+ * sur l'année suivante si leur semaine « recule » par rapport à l'étape
+ * précédente).
+ */
+export function operationsItp(
+  itp: ItpSemaineInput,
+  options: { anneeCulture: number; decalageZone?: number }
+): FenetreOperationItp[] {
+  const annee = options.anneeCulture
+  const decale = options.decalageZone ? appliquerDecalageItp(itp, options.decalageZone) : itp
+  const ops: FenetreOperationItp[] = []
+
+  if (decale.semaineSemis != null) {
+    const debut = calculerDateDepuisSemaine(annee, decale.semaineSemis)
+    ops.push({ type: "semis", debut, fin: new Date(debut.getTime() + 6 * JOUR_MS) })
+  }
+
+  if (decale.semainePlantation != null) {
+    const debut = dateSemaineChrono(annee, decale.semainePlantation, decale.semaineSemis ?? null)
+    ops.push({ type: "plantation", debut, fin: new Date(debut.getTime() + 6 * JOUR_MS) })
+  }
+
+  if (decale.semaineRecolte != null) {
+    const debut = dateSemaineChrono(
+      annee,
+      decale.semaineRecolte,
+      decale.semainePlantation ?? decale.semaineSemis ?? null
+    )
+    const nbSemaines =
+      decale.semaineRecolteFin != null
+        ? Math.max(1, decale.semaineRecolteFin - decale.semaineRecolte + 1)
+        : decale.dureeRecolte != null
+          ? Math.max(1, decale.dureeRecolte)
+          : 1
+    ops.push({ type: "recolte", debut, fin: new Date(debut.getTime() + (nbSemaines * 7 - 1) * JOUR_MS) })
+  }
+
+  return ops
+}
+
+/** Opérations d'un ITP dont la fenêtre couvre la semaine cible. */
+export function operationsItpDansSemaine(
+  itp: ItpSemaineInput,
+  cible: SemaineCourante,
+  options: { anneeCulture: number; decalageZone?: number }
+): Array<FenetreOperationItp & { date: string }> {
+  const debutCible = cible.debut.getTime()
+  const finCible = cible.fin.getTime() - 1 // dimanche minuit exclusif → fin de journée
+  const dansSemaine: Array<FenetreOperationItp & { date: string }> = []
+  for (const op of operationsItp(itp, options)) {
+    // Intersection de fenêtres : l'op touche la semaine si elle n'est ni
+    // entièrement avant, ni entièrement après.
+    if (op.debut.getTime() <= finCible && op.fin.getTime() >= debutCible) {
+      dansSemaine.push({ ...op, date: dateLocaleIso(op.debut) })
+    }
+  }
+  return dansSemaine
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Croisement avec les cultures actives
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Culture active telle que fournie par queries.ts (déjà jointe). */
+export interface CultureItpInput {
+  id: number
+  especeId: string
+  /** Année de planification — ancre les semaines ITP (défaut : année courante). */
+  annee: number | null
+  semisFait: boolean
+  plantationFaite: boolean
+  recolteFaite: boolean
+  couleur: string | null
+  especeNom: string | null
+  varieteNom: string | null
+  plancheName: string | null
+  ilot: string | null
+  /** ITP résolu (culture.itp, sinon meilleur ITP de l'espèce). */
+  itp: ItpSemaineInput | null
+}
+
+/** Flag « fait » qui éteint l'opération correspondante (pas de doublon de tâche). */
+const FAIT_PAR_TYPE: Record<TypeOperationItp, keyof Pick<CultureItpInput, "semisFait" | "plantationFaite" | "recolteFaite">> = {
+  semis: "semisFait",
+  plantation: "plantationFaite",
+  recolte: "recolteFaite",
+}
+
+const ORDRE_TYPE: Record<TypeOperationItp, number> = { semis: 0, plantation: 1, recolte: 2 }
+
+/**
+ * Tâches ITP de la semaine courante pour des cultures actives.
+ * Pure : les données sont déjà jointes depuis la base (queries.ts).
+ */
+export function tachesItpSemainePourCultures(
+  cultures: CultureItpInput[],
+  options: { userZone?: ZoneClimat | null; aujourdHui?: Date } = {}
+): TacheItpSemaine[] {
+  const cible = semaineCourante(options.aujourdHui ?? new Date())
+  const taches: TacheItpSemaine[] = []
+
+  for (const culture of cultures) {
+    const itp = culture.itp
+    if (!itp) continue
+    // Un ITP métropolitain n'est pas transposable hors de la métropole
+    // (zones tropicales/hémisphère sud : ITP dédiés uniquement).
+    if (!itpApplicableAZone(itp.zoneClimat, options.userZone ?? null)) continue
+
+    const anneeCulture = culture.annee ?? cible.annee
+    const decalageZone = decalageItpPourZone(itp.zoneClimat, options.userZone ?? null)
+
+    for (const op of operationsItpDansSemaine(itp, cible, { anneeCulture, decalageZone })) {
+      if (culture[FAIT_PAR_TYPE[op.type]]) continue
+      taches.push({
+        cultureId: culture.id,
+        type: op.type,
+        especeNom: culture.especeNom ?? culture.especeId,
+        varieteNom: culture.varieteNom,
+        plancheName: culture.plancheName,
+        ilot: culture.ilot,
+        date: op.date,
+        semaine: cible.semaine,
+        couleur: culture.couleur,
+      })
+    }
+  }
+
+  return taches.sort(
+    (a, b) =>
+      a.date.localeCompare(b.date) ||
+      ORDRE_TYPE[a.type] - ORDRE_TYPE[b.type] ||
+      a.especeNom.localeCompare(b.especeNom)
+  )
+}

--- a/src/lib/notifications/queries.ts
+++ b/src/lib/notifications/queries.ts
@@ -20,8 +20,13 @@ import {
   debutDeJournee,
   deciderIrrigationInutile,
   detecterAlertesMeteo,
+  detecterStocksAlimentsBas,
+  detecterStocksFertilisantsBas,
+  detecterStocksVarietesBas,
   finDeJournee,
   formatDateFr,
+  formaterStockBas,
+  fusionnerStocksBas,
 } from "./detect"
 import { semaineCourante, tachesItpSemainePourCultures } from "./itp-semaine"
 import type { CultureItpInput, ItpSemaineInput } from "./itp-semaine"
@@ -32,6 +37,12 @@ import type {
   TacheItpSemaine,
   TacheJour,
 } from "./types"
+import type {
+  StockAlimentInput,
+  StockBasDetecte,
+  StockFertilisantInput,
+  StockVarieteInput,
+} from "./detect"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Destinataires
@@ -74,6 +85,93 @@ export async function getCoordsUtilisateur(
     coords.push({ lat, lng })
   }
   return coords
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stocks bas — données par utilisateur + détection
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface StocksPourDetection {
+  varietes: StockVarieteInput[]
+  fertilisants: StockFertilisantInput[]
+  aliments: StockAlimentInput[]
+}
+
+/** Charge les stocks utilisateur nécessaires à la détection des seuils bas. */
+export async function fetchStocksPourDetection(userId: string): Promise<StocksPourDetection> {
+  const [varietes, fertilisants, aliments] = await Promise.all([
+    prisma.userStockVariete.findMany({
+      where: { userId },
+      select: {
+        id: true,
+        varieteId: true,
+        stockGraines: true,
+        stockPlants: true,
+        stockMinGraines: true,
+        stockMinPlants: true,
+        uniteStock: true,
+        variete: { select: { nom: true } },
+      },
+    }),
+    prisma.userStockFertilisant.findMany({
+      where: { userId },
+      select: {
+        id: true,
+        fertilisantId: true,
+        stock: true,
+        stockMin: true,
+      },
+    }),
+    prisma.userStockAliment.findMany({
+      where: { userId },
+      select: {
+        id: true,
+        alimentId: true,
+        stock: true,
+        stockMin: true,
+        aliment: { select: { nom: true } },
+      },
+    }),
+  ])
+
+  return {
+    varietes: varietes.map((stock) => ({
+      id: stock.id,
+      varieteId: stock.varieteId,
+      varieteNom: stock.variete.nom ?? stock.varieteId,
+      stockGraines: stock.stockGraines,
+      stockPlants: stock.stockPlants,
+      stockMinGraines: stock.stockMinGraines,
+      stockMinPlants: stock.stockMinPlants,
+      uniteStock: stock.uniteStock,
+    })),
+    fertilisants: fertilisants.map((stock) => ({
+      id: stock.id,
+      fertilisantId: stock.fertilisantId,
+      // Le référentiel Fertilisant n'a pas de champ nom : l'identifiant est
+      // actuellement le seul libellé stable disponible.
+      fertilisantNom: stock.fertilisantId,
+      stock: stock.stock,
+      stockMin: stock.stockMin,
+    })),
+    aliments: aliments.map((stock) => ({
+      id: stock.id,
+      alimentId: stock.alimentId,
+      alimentNom: stock.aliment.nom,
+      stock: stock.stock,
+      stockMin: stock.stockMin,
+    })),
+  }
+}
+
+/** Retourne les stocks sous seuil, tous types confondus et triés par criticité. */
+export async function chargerStocksBas(userId: string): Promise<StockBasDetecte[]> {
+  const stocks = await fetchStocksPourDetection(userId)
+  return fusionnerStocksBas(
+    detecterStocksVarietesBas(stocks.varietes),
+    detecterStocksFertilisantsBas(stocks.fertilisants),
+    detecterStocksAlimentsBas(stocks.aliments)
+  )
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -356,6 +454,21 @@ export async function chargerTachesDuJour(userId: string): Promise<TacheJour[]> 
 // ─────────────────────────────────────────────────────────────────────────────
 // Alertes urgentes (temps réel)
 // ─────────────────────────────────────────────────────────────────────────────
+
+const RATIO_STOCK_CRITIQUE = 0.5
+
+/** Stocks à moins de la moitié du seuil minimum. */
+async function detecterStocksCritiques(userId: string): Promise<AlerteUrgente[]> {
+  const stocks = await chargerStocksBas(userId)
+  return stocks
+    .filter((stock) => stock.ratio < RATIO_STOCK_CRITIQUE)
+    .map((stock) => ({
+      type: "stock-bas" as const,
+      titre: `stock critique : ${stock.nom}`,
+      message: `${formaterStockBas(stock)}. Réapprovisionnement recommandé.`,
+      key: stock.key,
+    }))
+}
 
 /** Irrigation(s) du jour probablement inutiles (pluie récente/prévue). */
 async function detecterIrrigationsInutiles(userId: string): Promise<AlerteUrgente[]> {
@@ -767,12 +880,13 @@ async function detecterTachesItpSemaine(userId: string): Promise<AlerteUrgente[]
 
 /** Toutes les alertes urgentes détectables pour un utilisateur. */
 export async function detecterAlertesUrgentes(userId: string): Promise<AlerteUrgente[]> {
-  const [irrigations, associations, retards, recoltes, itpSemaine] = await Promise.all([
+  const [irrigations, associations, retards, recoltes, itpSemaine, stocksCritiques] = await Promise.all([
     detecterIrrigationsInutiles(userId),
     detecterAssociationsIncompatibles(userId),
     detecterTachesEnRetard(userId),
     detecterRecoltesMures(userId),
     detecterTachesItpSemaine(userId),
+    detecterStocksCritiques(userId),
   ])
-  return [...irrigations, ...associations, ...retards, ...recoltes, ...itpSemaine]
+  return [...irrigations, ...associations, ...retards, ...recoltes, ...itpSemaine, ...stocksCritiques]
 }

--- a/src/lib/notifications/queries.ts
+++ b/src/lib/notifications/queries.ts
@@ -11,6 +11,9 @@ import prisma from "@/lib/prisma"
 import { fetchOpenMeteoForecast, fetchOpenMeteoHistory } from "@/lib/meteo"
 import { grouperIrrigationsPlanifieesParPlancheEtJour } from "@/lib/irrigation-planche"
 import { alertesAssociations } from "@/lib/associations-alertes"
+import { zoneEffectiveUser } from "@/lib/terroir"
+import type { ZoneClimat } from "@/lib/terroir"
+import { itpApplicableAZone } from "@/lib/calendrier-climat"
 import {
   calculerRecoltesMures,
   dateLocaleIso,
@@ -20,10 +23,13 @@ import {
   finDeJournee,
   formatDateFr,
 } from "./detect"
+import { semaineCourante, tachesItpSemainePourCultures } from "./itp-semaine"
+import type { CultureItpInput, ItpSemaineInput } from "./itp-semaine"
 import type {
   AlerteMeteoNotification,
   AlerteUrgente,
   DestinataireNotification,
+  TacheItpSemaine,
   TacheJour,
 } from "./types"
 
@@ -590,13 +596,183 @@ async function detecterRecoltesMures(userId: string): Promise<AlerteUrgente[]> {
   })
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Tâches ITP de la semaine (issue #16)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Champs ITP nécessaires au calcul des opérations hebdomadaires. */
+const CULTURE_ITP_SELECT = {
+  id: true,
+  especeId: true,
+  annee: true,
+  semisFait: true,
+  plantationFaite: true,
+  recolteFaite: true,
+  espece: {
+    select: {
+      nom: true,
+      couleur: true,
+      // ITP de l'espèce (repli quand la culture n'a pas d'ITP direct).
+      itps: {
+        select: {
+          id: true,
+          actif: true,
+          zoneClimat: true,
+          semaineSemis: true,
+          semainePlantation: true,
+          semaineRecolte: true,
+          semaineRecolteFin: true,
+          dureeRecolte: true,
+        },
+      },
+    },
+  },
+  variete: { select: { nom: true } },
+  planche: { select: { nom: true, ilot: true } },
+  itp: {
+    select: {
+      id: true,
+      actif: true,
+      zoneClimat: true,
+      semaineSemis: true,
+      semainePlantation: true,
+      semaineRecolte: true,
+      semaineRecolteFin: true,
+      dureeRecolte: true,
+    },
+  },
+} as const
+
+interface ItpCandidat {
+  id: string
+  actif: boolean
+  zoneClimat: ZoneClimat | null
+  semaineSemis: number | null
+  semainePlantation: number | null
+  semaineRecolte: number | null
+  semaineRecolteFin: number | null
+  dureeRecolte: number | null
+}
+
+/**
+ * Meilleur ITP de référence d'une espèce (repli quand la culture n'a pas
+ * d'ITP direct) : actif, applicable à la zone de l'utilisateur, de préférence
+ * calé sur SA zone, sinon générique (zoneClimat null), puis le plus complet
+ * (champs semis/plantation/récolte renseignés) ; départage déterministe par id.
+ */
+function meilleurItpEspece(itps: ItpCandidat[], userZone: ZoneClimat | null): ItpCandidat | null {
+  const candidats = itps.filter(
+    (itp) =>
+      itp.actif &&
+      itpApplicableAZone(itp.zoneClimat, userZone) &&
+      (itp.semaineSemis != null || itp.semainePlantation != null || itp.semaineRecolte != null)
+  )
+  if (candidats.length === 0) return null
+
+  const zones = candidats.filter((itp) => itp.zoneClimat === userZone)
+  const generiques = candidats.filter((itp) => itp.zoneClimat == null)
+  const pool = zones.length > 0 ? zones : generiques.length > 0 ? generiques : candidats
+
+  const completude = (itp: ItpCandidat): number =>
+    [itp.semaineSemis, itp.semainePlantation, itp.semaineRecolte].filter((v) => v != null).length
+  return [...pool].sort(
+    (a, b) => completude(b) - completude(a) || a.id.localeCompare(b.id)
+  )[0]
+}
+
+/**
+ * Tâches ITP de la semaine courante (lundi → dimanche) pour un utilisateur :
+ * opérations (semis/plantation/récolte) du calendrier ITP de ses cultures
+ * actives dont la fenêtre couvre la semaine. Non faites uniquement.
+ */
+export async function chargerTachesItpSemaine(
+  userId: string,
+  aujourdHui?: Date
+): Promise<TacheItpSemaine[]> {
+  const [userZone, cultures] = await Promise.all([
+    zoneEffectiveUser(prisma, userId),
+    prisma.culture.findMany({
+      // Cultures actives : cycle non terminé (NULL = en cours, 'v' = vivace
+      // continue). 'x' (terminée) et 'NS' sont exclues.
+      where: { userId, OR: [{ terminee: null }, { terminee: "v" }] },
+      select: CULTURE_ITP_SELECT,
+    }),
+  ])
+
+  const inputs: CultureItpInput[] = cultures.map((culture) => ({
+    id: culture.id,
+    especeId: culture.especeId,
+    annee: culture.annee,
+    semisFait: culture.semisFait,
+    plantationFaite: culture.plantationFaite,
+    recolteFaite: culture.recolteFaite,
+    couleur: culture.espece?.couleur ?? null,
+    especeNom: culture.espece?.nom ?? null,
+    varieteNom: culture.variete?.nom ?? null,
+    plancheName: culture.planche?.nom ?? null,
+    ilot: culture.planche?.ilot ?? null,
+    itp: (culture.itp ??
+      meilleurItpEspece((culture.espece?.itps ?? []) as ItpCandidat[], userZone)) as ItpSemaineInput |
+      null,
+  }))
+
+  return tachesItpSemainePourCultures(inputs, { userZone, aujourdHui })
+}
+
+/** Verbe d'action pour le message de l'alerte dédiée. */
+const VERBE_PAR_TYPE: Record<TacheItpSemaine["type"], string> = {
+  semis: "Semer",
+  plantation: "Planter",
+  recolte: "Récolter",
+}
+
+/**
+ * Alerte dédiée « tâches ITP de la semaine » : UN email par utilisateur et par
+ * semaine — la clé `tache-itp-semaine:YYYY-Sww` (anti-redondance store) change
+ * chaque lundi, donc l'alerte ne repart qu'une fois par semaine, quel que soit
+ * le nombre de scans. Résume les opérations ITP de la semaine sur les cultures
+ * actives ; le détail vit dans le résumé quotidien.
+ */
+async function detecterTachesItpSemaine(userId: string): Promise<AlerteUrgente[]> {
+  const taches = await chargerTachesItpSemaine(userId)
+  if (taches.length === 0) return []
+
+  const semaine = semaineCourante()
+  const types: TacheItpSemaine["type"][] = ["semis", "plantation", "recolte"]
+  const detail = types
+    .map((type) => taches.filter((tache) => tache.type === type))
+    .filter((liste) => liste.length > 0)
+    // Garde-fou anti-spam : on résume, le détail complet vit dans le résumé quotidien.
+    .map((liste) => {
+      const verbe = VERBE_PAR_TYPE[liste[0].type]
+      const libelles = liste
+        .slice(0, 12)
+        .map((tache) =>
+          tache.plancheName ? `${tache.especeNom} (planche ${tache.plancheName})` : tache.especeNom
+        )
+      const reste = liste.length - libelles.length
+      return `${verbe} ${libelles.join(", ")}${reste > 0 ? `… et ${reste} autre${reste > 1 ? "s" : ""}` : ""}`
+    })
+    .join(" ; ")
+
+  return [
+    {
+      type: "tache-itp-semaine",
+      titre: `semaine S${semaine.semaine}`,
+      message: `Cette semaine (du ${formatDateFr(semaine.debutIso)} au ${formatDateFr(semaine.finIso)}) : ${detail}.`,
+      key: `tache-itp-semaine:${semaine.annee}-S${semaine.semaine}`,
+    },
+  ]
+}
+
 /** Toutes les alertes urgentes détectables pour un utilisateur. */
 export async function detecterAlertesUrgentes(userId: string): Promise<AlerteUrgente[]> {
-  const [irrigations, associations, retards, recoltes] = await Promise.all([
+  const [irrigations, associations, retards, recoltes, itpSemaine] = await Promise.all([
     detecterIrrigationsInutiles(userId),
     detecterAssociationsIncompatibles(userId),
     detecterTachesEnRetard(userId),
     detecterRecoltesMures(userId),
+    detecterTachesItpSemaine(userId),
   ])
-  return [...irrigations, ...associations, ...retards, ...recoltes]
+  return [...irrigations, ...associations, ...retards, ...recoltes, ...itpSemaine]
 }

--- a/src/lib/notifications/queries.ts
+++ b/src/lib/notifications/queries.ts
@@ -1,0 +1,498 @@
+/**
+ * Couche DONNÉES du système de notifications.
+ *
+ * Réutilise volontairement les fonctions existantes plutôt que de les
+ * dupliquer : fetchOpenMeteoForecast / fetchOpenMeteoHistory (lib/meteo),
+ * grouperIrrigationsPlanifieesParPlancheEtJour (lib/irrigation-planche),
+ * alertesAssociations (lib/associations-alertes).
+ */
+
+import prisma from "@/lib/prisma"
+import { fetchOpenMeteoForecast, fetchOpenMeteoHistory } from "@/lib/meteo"
+import { grouperIrrigationsPlanifieesParPlancheEtJour } from "@/lib/irrigation-planche"
+import { alertesAssociations } from "@/lib/associations-alertes"
+import {
+  dateLocaleIso,
+  debutDeJournee,
+  deciderIrrigationInutile,
+  detecterAlertesMeteo,
+  finDeJournee,
+  formatDateFr,
+} from "./detect"
+import type {
+  AlerteMeteoNotification,
+  AlerteUrgente,
+  DestinataireNotification,
+  TacheJour,
+} from "./types"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Destinataires
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EMAIL_VALIDE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * Tous les users actifs ayant un email valide — par défaut activés pour les
+ * notifications métier. `emailOptOut` (désabonnement existant de Gleba pour
+ * les emails non transactionnels) est respecté.
+ */
+export async function getDestinatairesNotifications(): Promise<DestinataireNotification[]> {
+  const users = await prisma.user.findMany({
+    where: { active: true, emailOptOut: false },
+    select: { id: true, email: true, name: true },
+  })
+  return users
+    .filter((user) => user.email && EMAIL_VALIDE.test(user.email))
+    .map((user) => ({ id: user.id, email: user.email as string, name: user.name }))
+}
+
+/** Coordonnées (lat/lng) dédupliquées des parcelles géoréférencées. */
+export async function getCoordsUtilisateur(
+  userId: string
+): Promise<Array<{ lat: number; lng: number }>> {
+  const parcelles = await prisma.parcelleGeo.findMany({
+    where: { userId, centroidLat: { not: null }, centroidLng: { not: null } },
+    select: { centroidLat: true, centroidLng: true },
+  })
+  const vus = new Set<string>()
+  const coords: Array<{ lat: number; lng: number }> = []
+  for (const parcelle of parcelles) {
+    const lat = parcelle.centroidLat
+    const lng = parcelle.centroidLng
+    if (lat === null || lng === null) continue
+    const cle = `${Math.round(lat * 100)}_${Math.round(lng * 100)}`
+    if (vus.has(cle)) continue
+    vus.add(cle)
+    coords.push({ lat, lng })
+  }
+  return coords
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Météo — agrégat prévisions + pluie récente (même approche que /api/calendrier)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MeteoParCoord {
+  precipParCoordEtJour: Map<string, Map<string, number>>
+  pluieRecente3jParCoord: Map<string, number>
+}
+
+function coordKey(lat: number, lng: number): string {
+  return `${Math.round(lat * 100)}_${Math.round(lng * 100)}`
+}
+
+/** Précipitations prévues par jour + pluie cumulée sur 3 j, par coordonnée. */
+export async function fetchMeteoParCoord(
+  coords: Array<{ lat: number; lng: number }>
+): Promise<MeteoParCoord> {
+  const precipParCoordEtJour = new Map<string, Map<string, number>>()
+  const pluieRecente3jParCoord = new Map<string, number>()
+
+  await Promise.all(
+    coords.map(async ({ lat, lng }) => {
+      const cle = coordKey(lat, lng)
+      try {
+        const forecast = await fetchOpenMeteoForecast(lat, lng)
+        const parJour = new Map<string, number>()
+        for (const jour of forecast.daily) parJour.set(jour.date, jour.precipitation)
+        precipParCoordEtJour.set(cle, parJour)
+
+        const today = new Date()
+        const j3 = new Date(today)
+        j3.setDate(j3.getDate() - 3)
+        const yesterday = new Date(today)
+        yesterday.setDate(yesterday.getDate() - 1)
+        const historique = await fetchOpenMeteoHistory(
+          lat,
+          lng,
+          j3.toISOString().split("T")[0],
+          yesterday.toISOString().split("T")[0]
+        )
+        const pluieHisto = historique.reduce((somme, jour) => somme + jour.precipitation, 0)
+        const pluieAujourdhui = forecast.daily[0]?.precipitation ?? 0
+        pluieRecente3jParCoord.set(cle, pluieHisto + pluieAujourdhui)
+      } catch (error) {
+        // Une coordonnée en erreur ne doit pas faire échouer le scan entier
+        console.warn(`[notifications] Météo indisponible pour ${cle}:`, error)
+      }
+    })
+  )
+
+  return { precipParCoordEtJour, pluieRecente3jParCoord }
+}
+
+/** Alertes météo notifiables du jour (horizon 24 h) pour un utilisateur. */
+export async function recupererAlertesMeteoJour(userId: string): Promise<AlerteMeteoNotification[]> {
+  const coords = await getCoordsUtilisateur(userId)
+  if (coords.length === 0) return []
+
+  const alertes: AlerteMeteoNotification[] = []
+  for (const { lat, lng } of coords) {
+    try {
+      const { current, daily } = await fetchOpenMeteoForecast(lat, lng)
+      alertes.push(...detecterAlertesMeteo(daily, current, { horizonJours: 1 }))
+    } catch (error) {
+      console.warn(`[notifications] Prévisions indisponibles pour ${coordKey(lat, lng)}:`, error)
+    }
+  }
+  return alertes
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Résumé quotidien — tâches du jour
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CULTURE_SELECT = {
+  id: true,
+  especeId: true,
+  varieteId: true,
+  dateSemis: true,
+  datePlantation: true,
+  dateRecolte: true,
+  semisFait: true,
+  plantationFaite: true,
+  recolteFaite: true,
+  espece: { select: { couleur: true, nom: true } },
+  variete: { select: { nom: true } },
+  planche: { select: { nom: true, ilot: true, parcelleGeo: { select: { centroidLat: true, centroidLng: true } } } },
+} as const
+
+interface CultureAvecPlanche {
+  id: number
+  especeId: string
+  varieteId: string | null
+  semisFait: boolean
+  plantationFaite: boolean
+  recolteFaite: boolean
+  espece: { couleur: string | null; nom: string | null } | null
+  variete: { nom: string | null } | null
+  planche: { nom: string | null; ilot: string | null } | null
+}
+
+function cultureVersTache(
+  culture: CultureAvecPlanche,
+  type: "semis" | "plantation" | "recolte",
+  date: Date
+): TacheJour {
+  const fait = type === "semis" ? culture.semisFait : type === "plantation" ? culture.plantationFaite : culture.recolteFaite
+  return {
+    id: culture.id,
+    type,
+    especeNom: culture.espece?.nom ?? culture.especeId,
+    varieteNom: culture.variete?.nom ?? culture.varieteId ?? null,
+    plancheName: culture.planche?.nom ?? null,
+    ilot: culture.planche?.ilot ?? null,
+    date: date.toISOString(),
+    fait,
+    couleur: culture.espece?.couleur ?? null,
+  }
+}
+
+/**
+ * Tâches planifiées aujourd'hui (semis, plantations, récoltes, irrigations
+ * regroupées par planche/jour via la fonction existante). Inclut la météo
+ * d'irrigation (pluie prévue, passage probablement inutile).
+ */
+export async function chargerTachesDuJour(userId: string): Promise<TacheJour[]> {
+  const start = debutDeJournee()
+  const end = finDeJournee()
+
+  const [semis, plantations, recoltes, irrigations, coords] = await Promise.all([
+    prisma.culture.findMany({
+      where: { userId, dateSemis: { gte: start, lte: end } },
+      select: CULTURE_SELECT,
+    }),
+    prisma.culture.findMany({
+      where: { userId, datePlantation: { gte: start, lte: end } },
+      select: CULTURE_SELECT,
+    }),
+    prisma.culture.findMany({
+      where: { userId, dateRecolte: { gte: start, lte: end } },
+      select: CULTURE_SELECT,
+    }),
+    prisma.irrigationPlanifiee.findMany({
+      where: { userId, datePrevue: { gte: start, lte: end } },
+      include: {
+        culture: {
+          select: {
+            id: true,
+            especeId: true,
+            varieteId: true,
+            espece: { select: { couleur: true, nom: true } },
+            variete: { select: { nom: true } },
+            planche: {
+              select: {
+                nom: true,
+                ilot: true,
+                parcelleGeo: { select: { centroidLat: true, centroidLng: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+    getCoordsUtilisateur(userId),
+  ])
+
+  const taches: TacheJour[] = [
+    ...semis.map((c) => cultureVersTache(c as CultureAvecPlanche, "semis", c.dateSemis as Date)),
+    ...plantations.map((c) =>
+      cultureVersTache(c as CultureAvecPlanche, "plantation", c.datePlantation as Date)
+    ),
+    ...recoltes.map((c) => cultureVersTache(c as CultureAvecPlanche, "recolte", c.dateRecolte as Date)),
+  ]
+
+  if (irrigations.length === 0) return taches
+
+  const meteo = await fetchMeteoParCoord(coords)
+  const fallback = coords[0]
+
+  const mappees = irrigations.map((irrigation) => {
+    const parcelle = irrigation.culture.planche?.parcelleGeo
+    const lat = parcelle?.centroidLat ?? fallback?.lat
+    const lng = parcelle?.centroidLng ?? fallback?.lng
+    let pluiePrevue: number | null = null
+    let probablementInutile = false
+    if (lat !== undefined && lng !== undefined) {
+      const dateStr = irrigation.datePrevue.toISOString().split("T")[0]
+      pluiePrevue = meteo.precipParCoordEtJour.get(coordKey(lat, lng))?.get(dateStr) ?? null
+      const pluieRecente = meteo.pluieRecente3jParCoord.get(coordKey(lat, lng)) ?? 0
+      const joursAvant = Math.floor((irrigation.datePrevue.getTime() - Date.now()) / 86_400_000)
+      probablementInutile = deciderIrrigationInutile({ pluiePrevue, pluieRecente3j: pluieRecente, joursAvant })
+    }
+    return {
+      id: irrigation.id,
+      type: "irrigation" as const,
+      especeId: irrigation.culture.especeId,
+      varieteId: irrigation.culture.varieteId || null,
+      plancheId: irrigation.culture.planche?.nom || null,
+      plancheName: irrigation.culture.planche?.nom || null,
+      ilot: irrigation.culture.planche?.ilot || null,
+      datePrevue: irrigation.datePrevue.toISOString(),
+      date: irrigation.datePrevue.toISOString(),
+      fait: irrigation.fait,
+      couleur: irrigation.culture.espece?.couleur || null,
+      especeNom: irrigation.culture.espece?.nom ?? irrigation.culture.especeId,
+      varieteNom: irrigation.culture.variete?.nom ?? irrigation.culture.varieteId ?? null,
+      cultureId: irrigation.culture.id,
+      retardJours: 0,
+      pluiePrevue: pluiePrevue !== null ? Math.round(pluiePrevue * 10) / 10 : null,
+      probablementInutile,
+    }
+  })
+
+  const groupes = grouperIrrigationsPlanifieesParPlancheEtJour(mappees)
+  for (const groupe of groupes) {
+    taches.push({
+      id: groupe.irrigationIds[0],
+      type: "irrigation",
+      especeNom: groupe.especeNom ?? "Irrigation",
+      varieteNom: null,
+      plancheName: groupe.plancheName ?? null,
+      ilot: groupe.ilot ?? null,
+      date: groupe.datePrevue,
+      fait: groupe.fait,
+      couleur: groupe.couleur ?? null,
+      pluiePrevue: groupe.pluiePrevue,
+      probablementInutile: groupe.probablementInutile,
+    })
+  }
+
+  return taches
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alertes urgentes (temps réel)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Irrigation(s) du jour probablement inutiles (pluie récente/prévue). */
+async function detecterIrrigationsInutiles(userId: string): Promise<AlerteUrgente[]> {
+  const start = debutDeJournee()
+  const end = finDeJournee()
+  const [irrigations, coords] = await Promise.all([
+    prisma.irrigationPlanifiee.findMany({
+      where: { userId, fait: false, datePrevue: { gte: start, lte: end } },
+      include: {
+        culture: {
+          select: {
+            id: true,
+            especeId: true,
+            varieteId: true,
+            espece: { select: { nom: true } },
+            variete: { select: { nom: true } },
+            planche: {
+              select: {
+                nom: true,
+                ilot: true,
+                parcelleGeo: { select: { centroidLat: true, centroidLng: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+    getCoordsUtilisateur(userId),
+  ])
+  if (irrigations.length === 0) return []
+
+  const meteo = await fetchMeteoParCoord(coords)
+  const fallback = coords[0]
+
+  const mappees = irrigations.map((irrigation) => {
+    const parcelle = irrigation.culture.planche?.parcelleGeo
+    const lat = parcelle?.centroidLat ?? fallback?.lat
+    const lng = parcelle?.centroidLng ?? fallback?.lng
+    let pluiePrevue: number | null = null
+    let probablementInutile = false
+    if (lat !== undefined && lng !== undefined) {
+      const dateStr = irrigation.datePrevue.toISOString().split("T")[0]
+      pluiePrevue = meteo.precipParCoordEtJour.get(coordKey(lat, lng))?.get(dateStr) ?? null
+      const pluieRecente = meteo.pluieRecente3jParCoord.get(coordKey(lat, lng)) ?? 0
+      const joursAvant = Math.floor((irrigation.datePrevue.getTime() - Date.now()) / 86_400_000)
+      probablementInutile = deciderIrrigationInutile({ pluiePrevue, pluieRecente3j: pluieRecente, joursAvant })
+    }
+    return {
+      id: irrigation.id,
+      type: "irrigation" as const,
+      especeId: irrigation.culture.especeId,
+      varieteId: irrigation.culture.varieteId || null,
+      plancheId: irrigation.culture.planche?.nom || null,
+      plancheName: irrigation.culture.planche?.nom || null,
+      ilot: irrigation.culture.planche?.ilot || null,
+      datePrevue: irrigation.datePrevue.toISOString(),
+      date: irrigation.datePrevue.toISOString(),
+      fait: irrigation.fait,
+      couleur: null,
+      especeNom: irrigation.culture.espece?.nom ?? irrigation.culture.especeId,
+      varieteNom: irrigation.culture.variete?.nom ?? irrigation.culture.varieteId ?? null,
+      cultureId: irrigation.culture.id,
+      retardJours: 0,
+      pluiePrevue: pluiePrevue !== null ? Math.round(pluiePrevue * 10) / 10 : null,
+      probablementInutile,
+    }
+  })
+
+  const groupes = grouperIrrigationsPlanifieesParPlancheEtJour(mappees)
+  const urgentes: AlerteUrgente[] = []
+  const dateStr = dateLocaleIso()
+  for (const groupe of groupes) {
+    if (!groupe.probablementInutile) continue
+    const planche = groupe.plancheName ?? "sans planche"
+    urgentes.push({
+      type: "irrigation-inutile",
+      titre: `irrigation planche ${planche}`,
+      message: groupe.especeNom
+        ? `L'irrigation prévue aujourd'hui pour « ${groupe.especeNom} » (planche ${planche}) est probablement inutile : ${
+            groupe.pluiePrevue != null && groupe.pluiePrevue >= 5
+              ? `${groupe.pluiePrevue} mm de pluie sont prévus.`
+              : "les précipitations récentes couvrent le besoin en eau."
+          }`
+        : `Irrigation planche ${planche} probablement inutile : pluie suffisante.`,
+      key: `irrigation-inutile:${groupe.plancheId ?? groupe.cultureIds[0]}:${dateStr}`,
+    })
+  }
+  return urgentes
+}
+
+/** Associations défavorables (incompatibles) sur les planches actives. */
+async function detecterAssociationsIncompatibles(userId: string): Promise<AlerteUrgente[]> {
+  const planches = await prisma.planche.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      nom: true,
+      cultures: {
+        // Cultures « en place » : pas encore récoltées, cycle non terminé.
+        where: { recolteFaite: false, terminee: null },
+        select: { especeId: true },
+      },
+    },
+  })
+
+  const urgentes: AlerteUrgente[] = []
+  for (const planche of planches) {
+    const especesIds = planche.cultures.map((c) => c.especeId).filter(Boolean) as string[]
+    if (especesIds.length < 2) continue
+    let alertes
+    try {
+      alertes = await alertesAssociations(prisma, especesIds)
+    } catch (error) {
+      console.warn(`[notifications] alertesAssociations planche ${planche.id} en échec:`, error)
+      continue
+    }
+    for (const alerte of alertes) {
+      if (alerte.type !== "defavorable") continue
+      const [a, b] = alerte.especes
+      urgentes.push({
+        type: "association-incompatible",
+        titre: `association incompatible planche ${planche.nom}`,
+        message: alerte.message,
+        key: `association-incompatible:${planche.id}:${[a, b].sort().join("-")}`,
+      })
+    }
+  }
+  return urgentes
+}
+
+/** Tâches (semis/plantation/récolte) dont l'échéance est dépassée et non faites. */
+async function detecterTachesEnRetard(userId: string): Promise<AlerteUrgente[]> {
+  const start = debutDeJournee()
+  const cultures = await prisma.culture.findMany({
+    where: {
+      userId,
+      semisFait: false,
+      plantationFaite: false,
+      recolteFaite: false,
+      terminee: null,
+      OR: [
+        { dateSemis: { not: null, lt: start } },
+        { datePlantation: { not: null, lt: start } },
+        { dateRecolte: { not: null, lt: start } },
+      ],
+    },
+    select: {
+      id: true,
+      especeId: true,
+      dateSemis: true,
+      datePlantation: true,
+      dateRecolte: true,
+      espece: { select: { nom: true } },
+      planche: { select: { nom: true } },
+    },
+  })
+
+  const urgentes: AlerteUrgente[] = []
+  for (const culture of cultures) {
+    const actions: Array<{ kind: "semis" | "plantation" | "recolte"; date: Date }> = []
+    if (culture.dateSemis) actions.push({ kind: "semis", date: culture.dateSemis })
+    if (culture.datePlantation) actions.push({ kind: "plantation", date: culture.datePlantation })
+    if (culture.dateRecolte) actions.push({ kind: "recolte", date: culture.dateRecolte })
+    const enRetard = actions.filter((a) => a.date < start).sort((a, b) => a.date.getTime() - b.date.getTime())
+    if (enRetard.length === 0) continue
+
+    const { kind, date } = enRetard[0]
+    const jours = Math.max(1, Math.floor((start.getTime() - date.getTime()) / 86_400_000))
+    const especeNom = culture.espece?.nom ?? culture.especeId
+    const planche = culture.planche?.nom
+    urgentes.push({
+      type: "tache-retard",
+      titre: `${kind} en retard de ${jours} jour${jours > 1 ? "s" : ""}`,
+      message: `${kind[0].toUpperCase()}${kind.slice(1)} « ${especeNom} »${
+        planche ? ` (planche ${planche})` : ""
+      } prévu le ${formatDateFr(date.toISOString().split("T")[0])} et toujours non fait.`,
+      key: `tache-retard:${kind}:${culture.id}`,
+    })
+  }
+  return urgentes
+}
+
+/** Toutes les alertes urgentes détectables pour un utilisateur. */
+export async function detecterAlertesUrgentes(userId: string): Promise<AlerteUrgente[]> {
+  const [irrigations, associations, retards] = await Promise.all([
+    detecterIrrigationsInutiles(userId),
+    detecterAssociationsIncompatibles(userId),
+    detecterTachesEnRetard(userId),
+  ])
+  return [...irrigations, ...associations, ...retards]
+}

--- a/src/lib/notifications/queries.ts
+++ b/src/lib/notifications/queries.ts
@@ -12,6 +12,7 @@ import { fetchOpenMeteoForecast, fetchOpenMeteoHistory } from "@/lib/meteo"
 import { grouperIrrigationsPlanifieesParPlancheEtJour } from "@/lib/irrigation-planche"
 import { alertesAssociations } from "@/lib/associations-alertes"
 import {
+  calculerRecoltesMures,
   dateLocaleIso,
   debutDeJournee,
   deciderIrrigationInutile,
@@ -156,6 +157,7 @@ const CULTURE_SELECT = {
   espece: { select: { couleur: true, nom: true } },
   variete: { select: { nom: true } },
   planche: { select: { nom: true, ilot: true, parcelleGeo: { select: { centroidLat: true, centroidLng: true } } } },
+  itp: { select: { dureeCulture: true } },
 } as const
 
 interface CultureAvecPlanche {
@@ -168,6 +170,7 @@ interface CultureAvecPlanche {
   espece: { couleur: string | null; nom: string | null } | null
   variete: { nom: string | null } | null
   planche: { nom: string | null; ilot: string | null } | null
+  itp: { dureeCulture: number | null } | null
 }
 
 function cultureVersTache(
@@ -198,7 +201,7 @@ export async function chargerTachesDuJour(userId: string): Promise<TacheJour[]> 
   const start = debutDeJournee()
   const end = finDeJournee()
 
-  const [semis, plantations, recoltes, irrigations, coords] = await Promise.all([
+  const [semis, plantations, recoltes, culturesMures, irrigations, coords] = await Promise.all([
     prisma.culture.findMany({
       where: { userId, dateSemis: { gte: start, lte: end } },
       select: CULTURE_SELECT,
@@ -209,6 +212,19 @@ export async function chargerTachesDuJour(userId: string): Promise<TacheJour[]> 
     }),
     prisma.culture.findMany({
       where: { userId, dateRecolte: { gte: start, lte: end } },
+      select: CULTURE_SELECT,
+    }),
+    // Récoltes mûres du jour : cultures sans dateRecolte planifiée dont la
+    // maturité calculée (semis/plantation + durée culture ITP) tombe aujourd'hui
+    // ou date de quelques jours (rappel quotidien jusqu'à récolte).
+    prisma.culture.findMany({
+      where: {
+        userId,
+        recolteFaite: false,
+        terminee: null,
+        dateRecolte: null,
+        OR: [{ dateSemis: { not: null } }, { datePlantation: { not: null } }],
+      },
       select: CULTURE_SELECT,
     }),
     prisma.irrigationPlanifiee.findMany({
@@ -242,6 +258,35 @@ export async function chargerTachesDuJour(userId: string): Promise<TacheJour[]> 
     ),
     ...recoltes.map((c) => cultureVersTache(c as CultureAvecPlanche, "recolte", c.dateRecolte as Date)),
   ]
+
+  // Récoltes mûres du jour (maturité calculée, sans dateRecolte planifiée).
+  const muresJour = calculerRecoltesMures(
+    culturesMures.map((c) => ({
+      id: c.id,
+      dateSemis: c.dateSemis,
+      datePlantation: c.datePlantation,
+      recolteFaite: c.recolteFaite,
+      dureeCultureJours: c.itp?.dureeCulture ?? null,
+      especeNom: c.espece?.nom ?? c.especeId,
+      plancheNom: c.planche?.nom ?? null,
+    })),
+    new Date(),
+    // Fenêtre résumé : mûre aujourd'hui ou depuis 3 j max (rappel, pas de spam).
+    { avanceJours: 0, depassementJours: 3 }
+  )
+  for (const recolte of muresJour) {
+    taches.push({
+      id: recolte.cultureId,
+      type: "recolte",
+      especeNom: recolte.especeNom,
+      varieteNom: null,
+      plancheName: recolte.plancheNom ?? null,
+      ilot: null,
+      date: start.toISOString(),
+      fait: false,
+      couleur: null,
+    })
+  }
 
   if (irrigations.length === 0) return taches
 
@@ -487,12 +532,71 @@ async function detecterTachesEnRetard(userId: string): Promise<AlerteUrgente[]> 
   return urgentes
 }
 
+/**
+ * Cultures dont la maturité CALCULÉE (date semis/plantation + durée culture
+ * de l'ITP) est atteinte ou imminente et pas encore récoltées (issue #16).
+ * Uniquement les cultures SANS dateRecolte planifiée : celles qui en ont une
+ * sont déjà couvertes par le calendrier (tâches du jour) et l'alerte
+ * tache-retard. La maturité calculée supplée donc l'absence de planification.
+ */
+async function detecterRecoltesMures(userId: string): Promise<AlerteUrgente[]> {
+  const cultures = await prisma.culture.findMany({
+    where: {
+      userId,
+      recolteFaite: false,
+      terminee: null,
+      dateRecolte: null,
+      OR: [{ dateSemis: { not: null } }, { datePlantation: { not: null } }],
+    },
+    select: {
+      id: true,
+      especeId: true,
+      dateSemis: true,
+      datePlantation: true,
+      espece: { select: { nom: true } },
+      planche: { select: { nom: true } },
+      itp: { select: { dureeCulture: true } },
+    },
+  })
+
+  const mures = calculerRecoltesMures(
+    cultures.map((culture) => ({
+      id: culture.id,
+      dateSemis: culture.dateSemis,
+      datePlantation: culture.datePlantation,
+      recolteFaite: false,
+      dureeCultureJours: culture.itp?.dureeCulture ?? null,
+      especeNom: culture.espece?.nom ?? culture.especeId,
+      plancheNom: culture.planche?.nom ?? null,
+    }))
+  )
+
+  return mures.map((recolte) => {
+    const localisation = recolte.plancheNom ? ` de la planche ${recolte.plancheNom}` : ""
+    const quand =
+      recolte.joursRestants > 0
+        ? `mûre dans ${recolte.joursRestants} jour${recolte.joursRestants > 1 ? "s" : ""}`
+        : recolte.joursRestants === 0
+          ? "mûre aujourd'hui"
+          : `mûre depuis ${-recolte.joursRestants} jour${-recolte.joursRestants > 1 ? "s" : ""}`
+    return {
+      type: "recolte-mure" as const,
+      titre: recolte.plancheNom
+        ? `${recolte.especeNom} (planche ${recolte.plancheNom})`
+        : recolte.especeNom,
+      message: `La culture de ${recolte.especeNom}${localisation} est ${quand} (durée de culture ${recolte.dureeJours} j depuis le semis/plantation). Pensez à récolter.`,
+      key: `recolte-mure:${recolte.cultureId}:${recolte.dateMaturite}`,
+    }
+  })
+}
+
 /** Toutes les alertes urgentes détectables pour un utilisateur. */
 export async function detecterAlertesUrgentes(userId: string): Promise<AlerteUrgente[]> {
-  const [irrigations, associations, retards] = await Promise.all([
+  const [irrigations, associations, retards, recoltes] = await Promise.all([
     detecterIrrigationsInutiles(userId),
     detecterAssociationsIncompatibles(userId),
     detecterTachesEnRetard(userId),
+    detecterRecoltesMures(userId),
   ])
-  return [...irrigations, ...associations, ...retards]
+  return [...irrigations, ...associations, ...retards, ...recoltes]
 }

--- a/src/lib/notifications/recoltes-mures.test.ts
+++ b/src/lib/notifications/recoltes-mures.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest"
+import {
+  DUREE_CULTURE_FALLBACK_JOURS,
+  FENETRE_RECOLTE_MURE_AVANCE_JOURS,
+  calculerRecoltesMures,
+} from "./detect"
+import type { CultureRecolteInput } from "./detect"
+
+// Référence fixe : jeudi 13 août 2026 (même convention que detect.test.ts).
+const REFERENCE = new Date(2026, 7, 13)
+
+/** Culture semée `joursRestants` jours avant sa maturité (durée par défaut). */
+function culture(
+  overrides: Partial<CultureRecolteInput> & { dateSemis?: Date | null } = {}
+): CultureRecolteInput {
+  return {
+    id: 1,
+    dateSemis: new Date(2026, 7, 13 - 60), // mûre aujourd'hui avec durée 60 j
+    datePlantation: null,
+    recolteFaite: false,
+    dureeCultureJours: 60,
+    especeNom: "Carotte",
+    plancheNom: "P3",
+    ...overrides,
+  }
+}
+
+/** Date de semis telle que maturité = REFERENCE + joursRestants (durée `duree`). */
+function semisPourMaturite(joursRestants: number, duree: number): Date {
+  return new Date(2026, 7, 13 - duree + joursRestants)
+}
+
+describe("calculerRecoltesMures", () => {
+  it("détecte une culture mûre aujourd'hui (semis + durée = aujourd'hui)", () => {
+    const mures = calculerRecoltesMures([culture()], REFERENCE)
+    expect(mures).toHaveLength(1)
+    expect(mures[0]).toMatchObject({
+      cultureId: 1,
+      especeNom: "Carotte",
+      plancheNom: "P3",
+      joursRestants: 0,
+      dureeJours: 60,
+      dateMaturite: "2026-08-13",
+    })
+  })
+
+  it("prévient à J-3 avant la maturité (fenêtre de déclenchement)", () => {
+    const mures = calculerRecoltesMures(
+      [culture({ dateSemis: semisPourMaturite(3, 60) })],
+      REFERENCE
+    )
+    expect(mures).toHaveLength(1)
+    expect(mures[0].joursRestants).toBe(3)
+    expect(mures[0].dateMaturite).toBe("2026-08-16")
+  })
+
+  it("n'alerte pas au-delà de la fenêtre (J-4)", () => {
+    const mures = calculerRecoltesMures(
+      [culture({ dateSemis: semisPourMaturite(4, 60) })],
+      REFERENCE
+    )
+    expect(mures).toHaveLength(0)
+  })
+
+  it("exclut les cultures déjà récoltées", () => {
+    const mures = calculerRecoltesMures(
+      [culture({ recolteFaite: true }), culture({ id: 2, dateSemis: semisPourMaturite(1, 60) })],
+      REFERENCE
+    )
+    expect(mures).toHaveLength(1)
+    expect(mures[0].cultureId).toBe(2)
+  })
+
+  it("utilise la durée par défaut (90 j) quand l'ITP ne la donne pas", () => {
+    const mures = calculerRecoltesMures(
+      [culture({ dureeCultureJours: null, dateSemis: semisPourMaturite(0, 90) })],
+      REFERENCE
+    )
+    expect(mures).toHaveLength(1)
+    expect(mures[0].dureeJours).toBe(DUREE_CULTURE_FALLBACK_JOURS)
+    expect(mures[0].joursRestants).toBe(0)
+  })
+
+  it("privilégie la date de plantation quand elle existe", () => {
+    // Plantation il y a 60 j (mûre aujourd'hui) mais semis il y a 90 j :
+    // c'est la plantation qui doit piloter la maturité.
+    const mures = calculerRecoltesMures(
+      [
+        culture({
+          dateSemis: semisPourMaturite(30, 60),
+          datePlantation: semisPourMaturite(0, 60),
+        }),
+      ],
+      REFERENCE
+    )
+    expect(mures).toHaveLength(1)
+    expect(mures[0].joursRestants).toBe(0)
+  })
+
+  it("tolère un léger dépassement (mûre depuis 1 j) mais pas un oubli de 5 j", () => {
+    const recente = calculerRecoltesMures(
+      [culture({ dateSemis: semisPourMaturite(-1, 60) })],
+      REFERENCE
+    )
+    expect(recente).toHaveLength(1)
+    expect(recente[0].joursRestants).toBe(-1)
+
+    const oubliee = calculerRecoltesMures(
+      [culture({ dateSemis: semisPourMaturite(-5, 60) })],
+      REFERENCE
+    )
+    expect(oubliee).toHaveLength(0)
+  })
+
+  it("ignore les cultures sans date de semis ni de plantation", () => {
+    const mures = calculerRecoltesMures([culture({ dateSemis: null, datePlantation: null })], REFERENCE)
+    expect(mures).toHaveLength(0)
+  })
+
+  it("trie les récoltes des plus imminentes aux moins imminentes", () => {
+    const mures = calculerRecoltesMures(
+      [
+        culture({ id: 3, dateSemis: semisPourMaturite(2, 60) }),
+        culture({ id: 1, dateSemis: semisPourMaturite(0, 60) }),
+        culture({ id: 2, dateSemis: semisPourMaturite(3, 60) }),
+      ],
+      REFERENCE
+    )
+    expect(mures.map((m) => m.cultureId)).toEqual([1, 3, 2])
+  })
+
+  it("respecte une fenêtre personnalisée (résumé quotidien : jour J, sans avance)", () => {
+    // Maturité demain : exclue du résumé du jour (avance 0)…
+    const demain = calculerRecoltesMures(
+      [culture({ dateSemis: semisPourMaturite(1, 60) })],
+      REFERENCE,
+      { avanceJours: 0, depassementJours: 3 }
+    )
+    expect(demain).toHaveLength(0)
+
+    // …mais mûre depuis 2 j : rappelée (dépassement borné à 3 j).
+    const depuis2j = calculerRecoltesMures(
+      [culture({ dateSemis: semisPourMaturite(-2, 60) })],
+      REFERENCE,
+      { avanceJours: 0, depassementJours: 3 }
+    )
+    expect(depuis2j).toHaveLength(1)
+    expect(depuis2j[0].joursRestants).toBe(-2)
+  })
+
+  it("expose une fenêtre de déclenchement par défaut de 3 jours", () => {
+    expect(FENETRE_RECOLTE_MURE_AVANCE_JOURS).toBe(3)
+  })
+
+  it("ne détecte rien sans aucune culture", () => {
+    expect(calculerRecoltesMures([], REFERENCE)).toHaveLength(0)
+  })
+})

--- a/src/lib/notifications/resume.test.ts
+++ b/src/lib/notifications/resume.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest"
+import { construireResume, grouperTachesParType, nombreTachesAFaire } from "./resume"
+import { getMeteoIntervalMinutes, getResumeCronExpression, parseHeureResume } from "./config"
+import type { TacheJour } from "./types"
+
+const tacheSemis: TacheJour = {
+  id: 1,
+  type: "semis",
+  especeNom: "Carotte",
+  varieteNom: null,
+  plancheName: "S1",
+  ilot: "A",
+  date: "2026-08-10T08:00:00.000Z",
+  fait: false,
+  couleur: "#22c55e",
+}
+
+const tacheIrrigation: TacheJour = {
+  id: 2,
+  type: "irrigation",
+  especeNom: "Tomate + Laitue",
+  varieteNom: null,
+  plancheName: "S4",
+  ilot: "A",
+  date: "2026-08-10T06:00:00.000Z",
+  fait: false,
+  couleur: "#0ea5e9",
+  pluiePrevue: 8,
+  probablementInutile: true,
+}
+
+const tacheRecolteFait: TacheJour = {
+  id: 3,
+  type: "recolte",
+  especeNom: "Courgette",
+  varieteNom: null,
+  plancheName: null,
+  ilot: null,
+  date: "2026-08-10T10:00:00.000Z",
+  fait: true,
+  couleur: null,
+}
+
+describe("construireResume", () => {
+  it("assemble un résumé avec date par défaut", () => {
+    const resume = construireResume([tacheSemis], [])
+    expect(resume.taches).toHaveLength(1)
+    expect(resume.alertesMeteo).toHaveLength(0)
+    expect(resume.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it("trie les tâches par date puis par type", () => {
+    const resume = construireResume([tacheSemis, tacheIrrigation, tacheRecolteFait], [])
+    expect(resume.taches.map((t) => t.id)).toEqual([2, 1, 3])
+  })
+
+  it("trie les alertes météo par date", () => {
+    const resume = construireResume([], [
+      { type: "canicule", date: "2026-08-12", niveau: "attention", message: "x", details: "y", key: "canicule:2026-08-12" },
+      { type: "gel", date: "2026-08-10", niveau: "attention", message: "x", details: "y", key: "gel:2026-08-10" },
+    ])
+    expect(resume.alertesMeteo.map((a) => a.date)).toEqual(["2026-08-10", "2026-08-12"])
+  })
+})
+
+describe("grouperTachesParType / nombreTachesAFaire", () => {
+  it("regroupe par type", () => {
+    const groupes = grouperTachesParType([tacheSemis, tacheIrrigation, tacheRecolteFait])
+    expect(groupes.get("semis")).toHaveLength(1)
+    expect(groupes.get("irrigation")).toHaveLength(1)
+    expect(groupes.get("recolte")).toHaveLength(1)
+  })
+
+  it("compte les tâches restant à faire", () => {
+    expect(nombreTachesAFaire([tacheSemis, tacheIrrigation, tacheRecolteFait])).toBe(2)
+  })
+})
+
+describe("config du scheduler", () => {
+  it("parse HH:MM valide", () => {
+    expect(parseHeureResume("07:00")).toEqual({ hour: 7, minute: 0 })
+    expect(parseHeureResume("23:59")).toEqual({ hour: 23, minute: 59 })
+  })
+
+  it("rejette les heures invalides", () => {
+    expect(parseHeureResume("24:00")).toBeNull()
+    expect(parseHeureResume("07:60")).toBeNull()
+    expect(parseHeureResume("abc")).toBeNull()
+    expect(parseHeureResume(undefined)).toBeNull()
+  })
+
+  it("génère l'expression cron du résumé (défaut 07:00)", () => {
+    expect(getResumeCronExpression({})).toBe("0 7 * * *")
+    expect(getResumeCronExpression({ NOTIF_RESUME_HEURE: "06:45" })).toBe("45 6 * * *")
+    expect(getResumeCronExpression({ NOTIF_RESUME_HEURE: "invalide" })).toBe("0 7 * * *")
+  })
+
+  it("borne l'intervalle météo (défaut 30, min 5)", () => {
+    expect(getMeteoIntervalMinutes({})).toBe(30)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "10" })).toBe(10)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "2" })).toBe(5)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "99999" })).toBe(1440)
+    expect(getMeteoIntervalMinutes({ NOTIF_METEO_INTERVAL_MIN: "abc" })).toBe(30)
+  })
+})

--- a/src/lib/notifications/resume.test.ts
+++ b/src/lib/notifications/resume.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { construireResume, grouperTachesParType, nombreTachesAFaire } from "./resume"
 import { getMeteoIntervalMinutes, getResumeCronExpression, parseHeureResume } from "./config"
-import type { TacheJour } from "./types"
+import type { StockBas, TacheJour } from "./types"
 
 const tacheSemis: TacheJour = {
   id: 1,
@@ -60,6 +60,17 @@ describe("construireResume", () => {
       { type: "gel", date: "2026-08-10", niveau: "attention", message: "x", details: "y", key: "gel:2026-08-10" },
     ])
     expect(resume.alertesMeteo.map((a) => a.date)).toEqual(["2026-08-10", "2026-08-12"])
+  })
+
+  it("inclut les stocks bas non vides dans l'ordre de criticité", () => {
+    const stocks: StockBas[] = [
+      { type: "variete", stockId: 1, nom: "Tomate", unite: "g", quantite: 40, seuilMin: 100, ratio: 0.4, key: "stock-bas:variete:1" },
+      { type: "aliment", stockId: 2, nom: "Foin", unite: "kg", quantite: 0, seuilMin: 10, ratio: 0, key: "stock-bas:aliment:2" },
+    ]
+    const resume = construireResume([], [], { stocksBas: stocks })
+    expect(resume.stocksBas?.map((stock) => stock.nom)).toEqual(["Foin", "Tomate"])
+
+    expect(construireResume([], []).stocksBas).toBeUndefined()
   })
 })
 

--- a/src/lib/notifications/resume.ts
+++ b/src/lib/notifications/resume.ts
@@ -5,13 +5,19 @@
  */
 
 import { dateLocaleIso } from "./detect"
-import type { AlerteMeteoNotification, ResumeQuotidien, TacheJour, TypeTache } from "./types"
+import type {
+  AlerteMeteoNotification,
+  ResumeQuotidien,
+  TacheItpSemaine,
+  TacheJour,
+  TypeTache,
+} from "./types"
 
 /** Trie les tâches par date puis par type, et les alertes par date. */
 export function construireResume(
   taches: TacheJour[],
   alertes: AlerteMeteoNotification[],
-  options: { date?: string } = {}
+  options: { date?: string; tachesItpSemaine?: TacheItpSemaine[] } = {}
 ): ResumeQuotidien {
   return {
     date: options.date ?? dateLocaleIso(),
@@ -21,6 +27,7 @@ export function construireResume(
         ordreTypeTache(a.type) - ordreTypeTache(b.type)
     ),
     alertesMeteo: [...alertes].sort((a, b) => a.date.localeCompare(b.date)),
+    tachesItpSemaine: options.tachesItpSemaine,
   }
 }
 

--- a/src/lib/notifications/resume.ts
+++ b/src/lib/notifications/resume.ts
@@ -8,6 +8,7 @@ import { dateLocaleIso } from "./detect"
 import type {
   AlerteMeteoNotification,
   ResumeQuotidien,
+  StockBas,
   TacheItpSemaine,
   TacheJour,
   TypeTache,
@@ -17,8 +18,11 @@ import type {
 export function construireResume(
   taches: TacheJour[],
   alertes: AlerteMeteoNotification[],
-  options: { date?: string; tachesItpSemaine?: TacheItpSemaine[] } = {}
+  options: { date?: string; tachesItpSemaine?: TacheItpSemaine[]; stocksBas?: StockBas[] } = {}
 ): ResumeQuotidien {
+  const stocksBas = options.stocksBas?.length
+    ? [...options.stocksBas].sort((a, b) => a.ratio - b.ratio)
+    : undefined
   return {
     date: options.date ?? dateLocaleIso(),
     taches: [...taches].sort(
@@ -28,6 +32,7 @@ export function construireResume(
     ),
     alertesMeteo: [...alertes].sort((a, b) => a.date.localeCompare(b.date)),
     tachesItpSemaine: options.tachesItpSemaine,
+    stocksBas,
   }
 }
 

--- a/src/lib/notifications/resume.ts
+++ b/src/lib/notifications/resume.ts
@@ -1,0 +1,96 @@
+/**
+ * Assemblage PUR du résumé quotidien « Quoi faire ce matin ? ».
+ * La partie base de données vit dans `queries.ts` ; ici tout est testable
+ * sans Prisma ni réseau.
+ */
+
+import { dateLocaleIso } from "./detect"
+import type { AlerteMeteoNotification, ResumeQuotidien, TacheJour, TypeTache } from "./types"
+
+/** Trie les tâches par date puis par type, et les alertes par date. */
+export function construireResume(
+  taches: TacheJour[],
+  alertes: AlerteMeteoNotification[],
+  options: { date?: string } = {}
+): ResumeQuotidien {
+  return {
+    date: options.date ?? dateLocaleIso(),
+    taches: [...taches].sort(
+      (a, b) =>
+        new Date(a.date).getTime() - new Date(b.date).getTime() ||
+        ordreTypeTache(a.type) - ordreTypeTache(b.type)
+    ),
+    alertesMeteo: [...alertes].sort((a, b) => a.date.localeCompare(b.date)),
+  }
+}
+
+const ORDRE_TYPES: Record<TypeTache, number> = {
+  semis: 0,
+  plantation: 1,
+  recolte: 2,
+  irrigation: 3,
+}
+
+function ordreTypeTache(type: TypeTache): number {
+  return ORDRE_TYPES[type] ?? 99
+}
+
+export function labelTypeTache(type: TypeTache): string {
+  switch (type) {
+    case "semis":
+      return "Semis"
+    case "plantation":
+      return "Plantations"
+    case "recolte":
+      return "Récoltes"
+    case "irrigation":
+      return "Irrigations"
+  }
+}
+
+export function labelAlerteMeteo(type: AlerteMeteoNotification["type"]): string {
+  switch (type) {
+    case "gel":
+      return "gel attendu"
+    case "orage":
+      return "orage en cours"
+    case "canicule":
+      return "canicule"
+    case "vent":
+      return "vent fort"
+    case "pluie":
+      return "pluie abondante"
+  }
+}
+
+/** Libellé court d'une alerte pour l'objet de l'email (« gel attendu »). */
+export function labelAlerteMeteoCourt(type: AlerteMeteoNotification["type"]): string {
+  switch (type) {
+    case "gel":
+      return "gel attendu"
+    case "orage":
+      return "orage"
+    case "canicule":
+      return "canicule"
+    case "vent":
+      return "vent fort"
+    case "pluie":
+      return "pluie abondante"
+  }
+}
+
+/** Regroupe les tâches par type pour le rendu en sections. */
+export function grouperTachesParType(taches: TacheJour[]): Map<TypeTache, TacheJour[]> {
+  const groupes = new Map<TypeTache, TacheJour[]>()
+  for (const tache of taches) {
+    const liste = groupes.get(tache.type) ?? []
+    liste.push(tache)
+    groupes.set(tache.type, liste)
+  }
+  return groupes
+}
+
+/** Nombre de tâches restant à faire (pour le pied du résumé). */
+export function nombreTachesAFaire(taches: TacheJour[]): number {
+  return taches.filter((t) => !t.fait).length
+}

--- a/src/lib/notifications/scheduler.ts
+++ b/src/lib/notifications/scheduler.ts
@@ -1,0 +1,95 @@
+/**
+ * Scheduler interne au conteneur (node-cron), initialisé au démarrage du
+ * serveur Next.js via `src/instrumentation.ts` (register()).
+ *
+ * - Résumé quotidien : horaire fixe NOTIF_RESUME_HEURE (défaut 07:00).
+ * - Surveillance météo + urgences : toutes les NOTIF_METEO_INTERVAL_MIN
+ *   minutes (défaut 30), plus un premier scan ~30 s après le boot.
+ *
+ * Robustesse : l'init est enveloppé en try/catch (ne fait jamais crasher le
+ * démarrage) ; chaque run est isolé et ne peut pas se chevaucher avec le
+ * précédent.
+ */
+
+import cron from "node-cron"
+import { getMeteoIntervalMinutes, getResumeCronExpression } from "./config"
+import { envoyerAlertesMeteoTempsReel, envoyerAlertesUrgentes, envoyerResumeQuotidien, notificationsEnabled } from "./sender"
+
+let initialized = false
+
+/** Délai avant le premier scan au démarrage (laisse la DB se réveiller). */
+const DELAI_PREMIER_SCAN_MS = 30_000
+
+let scanEnCours = false
+
+async function runScanMeteoEtUrgent(): Promise<void> {
+  if (scanEnCours) {
+    console.warn("[notifications] Scan précédent encore en cours, saut de cycle")
+    return
+  }
+  scanEnCours = true
+  try {
+    const meteo = await envoyerAlertesMeteoTempsReel()
+    const urgentes = await envoyerAlertesUrgentes()
+    if (meteo > 0 || urgentes > 0) {
+      console.log(`[notifications] Scan : ${meteo} alerte(s) météo, ${urgentes} action(s) urgente(s) envoyée(s)`)
+    }
+  } catch (error) {
+    console.error("[notifications] Échec du scan météo/urgent:", error)
+  } finally {
+    scanEnCours = false
+  }
+}
+
+/**
+ * Initialise le scheduler. Appelé une seule fois (module-level flag) depuis
+ * instrumentation.register(). Ne lève jamais.
+ */
+export function initNotifScheduler(): void {
+  if (initialized) return
+  // Pendant `next build`, register() peut être exécuté par le serveur de
+  // compilation : on ne planifie rien.
+  if (process.env.NEXT_PHASE === "phase-production-build") return
+
+  initialized = true
+  try {
+    if (!notificationsEnabled()) {
+      console.log(
+        "[notifications] Désactivées — définir SMTP_HOST/SMTP_USER (ou NOTIF_ENABLED=true après configuration SMTP)"
+      )
+      return
+    }
+
+    const intervalMinutes = getMeteoIntervalMinutes()
+    const resumeExpression = getResumeCronExpression()
+
+    // Premier scan au démarrage (météo + urgences), après un court délai.
+    setTimeout(() => {
+      runScanMeteoEtUrgent().catch((error) => console.error("[notifications] Premier scan en échec:", error))
+    }, DELAI_PREMIER_SCAN_MS)
+
+    // Surveillance météo + urgences à intervalle régulier.
+    cron.schedule(`*/${intervalMinutes} * * * *`, () => {
+      runScanMeteoEtUrgent().catch((error) => console.error("[notifications] Scan planifié en échec:", error))
+    })
+
+    // Résumé quotidien à l'heure configurée (fuseau du conteneur, TZ).
+    cron.schedule(
+      resumeExpression,
+      () => {
+        envoyerResumeQuotidien()
+          .then((n) => {
+            if (n > 0) console.log(`[notifications] Résumé quotidien envoyé à ${n} destinataire(s)`)
+          })
+          .catch((error) => console.error("[notifications] Résumé quotidien en échec:", error))
+      },
+      { timezone: process.env.TZ || "Europe/Paris" }
+    )
+
+    console.log(
+      `[notifications] Scheduler démarré — résumé quotidien à ${resumeExpression} (NOTIF_RESUME_HEURE) — scan météo/urgent toutes les ${intervalMinutes} min`
+    )
+  } catch (error) {
+    console.error("[notifications] Impossible de démarrer le scheduler:", error)
+  }
+}

--- a/src/lib/notifications/sender.ts
+++ b/src/lib/notifications/sender.ts
@@ -9,6 +9,7 @@
 
 import { sendMail } from "@/lib/mail"
 import {
+  chargerStocksBas,
   chargerTachesDuJour,
   chargerTachesItpSemaine,
   detecterAlertesUrgentes,
@@ -136,12 +137,13 @@ export async function envoyerResumeQuotidien(): Promise<number> {
   let total = 0
   for (const user of users) {
     try {
-      const [taches, alertesMeteo, tachesItpSemaine] = await Promise.all([
+      const [taches, alertesMeteo, tachesItpSemaine, stocksBas] = await Promise.all([
         chargerTachesDuJour(user.id),
         recupererAlertesMeteoJour(user.id),
         chargerTachesItpSemaine(user.id),
+        chargerStocksBas(user.id),
       ])
-      const resume = construireResume(taches, alertesMeteo, { tachesItpSemaine })
+      const resume = construireResume(taches, alertesMeteo, { tachesItpSemaine, stocksBas })
       const { subject, html } = resumeQuotidienEmail(user, resume)
       await sendMail({ to: user.email, subject, html })
       total++

--- a/src/lib/notifications/sender.ts
+++ b/src/lib/notifications/sender.ts
@@ -1,0 +1,151 @@
+/**
+ * Orchestration des envois : résumé quotidien + alertes temps réel.
+ *
+ * Chaque exécution est isolée (try/catch par utilisateur et par étape) :
+ * une erreur de météo, de SMTP ou de base ne fait jamais tomber le cron.
+ * L'anti-redondance (store en mémoire) est scellée par utilisateur pour
+ * que chaque compte reçoive bien ses propres alertes.
+ */
+
+import { sendMail } from "@/lib/mail"
+import {
+  chargerTachesDuJour,
+  detecterAlertesUrgentes,
+  getDestinatairesNotifications,
+  getCoordsUtilisateur,
+  recupererAlertesMeteoJour,
+} from "./queries"
+import {
+  alerteDejaEnvoyee,
+  marquerAlerteEnvoyee,
+  nettoyerAlertesEnvoyees,
+} from "./store"
+import { detecterAlertesMeteo } from "./detect"
+import { construireResume } from "./resume"
+import { alerteMeteoEmail, alerteUrgenteEmail, resumeQuotidienEmail } from "./templates"
+import type { AlerteMeteoNotification, DestinataireNotification } from "./types"
+import { fetchOpenMeteoForecast } from "@/lib/meteo"
+
+/** Nombre maximal d'emails envoyés par utilisateur et par scan (anti-spam). */
+const MAX_EMAILS_PAR_UTILISATEUR = 15
+
+/** Les notifications sont-elles activées ? (défaut : oui si SMTP configuré). */
+export function notificationsEnabled(): boolean {
+  if (process.env.NOTIF_ENABLED === "false") return false
+  return Boolean(process.env.SMTP_HOST && process.env.SMTP_USER)
+}
+
+/**
+ * Scan météo temps réel : pour chaque utilisateur, détecte les conditions
+ * dangereuses sur les 48 h à venir et email chaque nouvelle alerte.
+ */
+export async function envoyerAlertesMeteoTempsReel(): Promise<number> {
+  if (!notificationsEnabled()) return 0
+  nettoyerAlertesEnvoyees()
+  const users = await getDestinatairesNotifications()
+  let total = 0
+  for (const user of users) {
+    try {
+      total += await traiterMeteoUtilisateur(user)
+    } catch (error) {
+      console.error(`[notifications] Scan météo échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}
+
+async function traiterMeteoUtilisateur(user: DestinataireNotification): Promise<number> {
+  const coords = await getCoordsUtilisateur(user.id)
+  if (coords.length === 0) return 0
+
+  const alertes: AlerteMeteoNotification[] = []
+  for (const { lat, lng } of coords) {
+    try {
+      const { current, daily } = await fetchOpenMeteoForecast(lat, lng)
+      // Temps réel = conditions actuelles + 48 h (gel de la nuit, canicule du lendemain…)
+      alertes.push(...detecterAlertesMeteo(daily, current, { horizonJours: 2 }))
+    } catch (error) {
+      console.warn(`[notifications] Prévisions indisponibles (${lat},${lng}):`, error)
+    }
+  }
+
+  // Déduplication au sein d'un même scan (2 parcelles proches → 1 email)
+  const envoyees = new Set<string>()
+  let total = 0
+  for (const alerte of alertes) {
+    if (total >= MAX_EMAILS_PAR_UTILISATEUR) {
+      console.warn(`[notifications] Cap anti-spam atteint pour ${user.email}`)
+      break
+    }
+    const cle = `${user.id}:${alerte.key}`
+    if (envoyees.has(cle) || alerteDejaEnvoyee(cle)) continue
+    try {
+      const { subject, html } = alerteMeteoEmail(user, alerte)
+      await sendMail({ to: user.email, subject, html })
+      marquerAlerteEnvoyee(cle, { until: alerte.date })
+      envoyees.add(cle)
+      total++
+    } catch (error) {
+      console.error(`[notifications] Envoi alerte météo échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}
+
+/**
+ * Scan temps réel des actions urgentes : irrigations probablement inutiles,
+ * associations incompatibles, tâches en retard.
+ */
+export async function envoyerAlertesUrgentes(): Promise<number> {
+  if (!notificationsEnabled()) return 0
+  const users = await getDestinatairesNotifications()
+  let total = 0
+  for (const user of users) {
+    try {
+      const urgentes = await detecterAlertesUrgentes(user.id)
+      let envoyees = 0
+      for (const alerte of urgentes) {
+        if (envoyees >= MAX_EMAILS_PAR_UTILISATEUR) {
+          console.warn(`[notifications] Cap anti-spam atteint pour ${user.email}`)
+          break
+        }
+        const cle = `${user.id}:${alerte.key}`
+        if (alerteDejaEnvoyee(cle)) continue
+        try {
+          const { subject, html } = alerteUrgenteEmail(user, alerte)
+          await sendMail({ to: user.email, subject, html })
+          marquerAlerteEnvoyee(cle)
+          envoyees++
+        } catch (error) {
+          console.error(`[notifications] Envoi alerte urgente échoué pour ${user.email}:`, error)
+        }
+      }
+      total += envoyees
+    } catch (error) {
+      console.error(`[notifications] Scan urgent échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}
+
+/** Résumé quotidien « Quoi faire ce matin ? » pour chaque utilisateur. */
+export async function envoyerResumeQuotidien(): Promise<number> {
+  if (!notificationsEnabled()) return 0
+  const users = await getDestinatairesNotifications()
+  let total = 0
+  for (const user of users) {
+    try {
+      const [taches, alertesMeteo] = await Promise.all([
+        chargerTachesDuJour(user.id),
+        recupererAlertesMeteoJour(user.id),
+      ])
+      const resume = construireResume(taches, alertesMeteo)
+      const { subject, html } = resumeQuotidienEmail(user, resume)
+      await sendMail({ to: user.email, subject, html })
+      total++
+    } catch (error) {
+      console.error(`[notifications] Résumé quotidien échoué pour ${user.email}:`, error)
+    }
+  }
+  return total
+}

--- a/src/lib/notifications/sender.ts
+++ b/src/lib/notifications/sender.ts
@@ -10,6 +10,7 @@
 import { sendMail } from "@/lib/mail"
 import {
   chargerTachesDuJour,
+  chargerTachesItpSemaine,
   detecterAlertesUrgentes,
   getDestinatairesNotifications,
   getCoordsUtilisateur,
@@ -135,11 +136,12 @@ export async function envoyerResumeQuotidien(): Promise<number> {
   let total = 0
   for (const user of users) {
     try {
-      const [taches, alertesMeteo] = await Promise.all([
+      const [taches, alertesMeteo, tachesItpSemaine] = await Promise.all([
         chargerTachesDuJour(user.id),
         recupererAlertesMeteoJour(user.id),
+        chargerTachesItpSemaine(user.id),
       ])
-      const resume = construireResume(taches, alertesMeteo)
+      const resume = construireResume(taches, alertesMeteo, { tachesItpSemaine })
       const { subject, html } = resumeQuotidienEmail(user, resume)
       await sendMail({ to: user.email, subject, html })
       total++

--- a/src/lib/notifications/store.test.ts
+++ b/src/lib/notifications/store.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  alerteDejaEnvoyee,
+  marquerAlerteEnvoyee,
+  nettoyerAlertesEnvoyees,
+  nombreAlertesMemorisees,
+  resetStorePourTests,
+} from "./store"
+
+function hierIso(): string {
+  const hier = new Date()
+  hier.setDate(hier.getDate() - 1)
+  const m = String(hier.getMonth() + 1).padStart(2, "0")
+  const d = String(hier.getDate()).padStart(2, "0")
+  return `${hier.getFullYear()}-${m}-${d}`
+}
+
+describe("store anti-redondance", () => {
+  beforeEach(() => {
+    resetStorePourTests()
+  })
+
+  it("une alerte non envoyée n'est pas mémorisée", () => {
+    expect(alerteDejaEnvoyee("gel:2026-08-10")).toBe(false)
+    expect(nombreAlertesMemorisees()).toBe(0)
+  })
+
+  it("bloque une seconde notification de la même alerte active", () => {
+    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
+    expect(alerteDejaEnvoyee("u1:gel:2026-08-10")).toBe(true)
+  })
+
+  it("l'anti-redondance est scellée par utilisateur", () => {
+    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
+    // L'utilisateur 2 dans la même région doit bien être notifié
+    expect(alerteDejaEnvoyee("u2:gel:2026-08-10")).toBe(false)
+  })
+
+  it("libère l'alerte une fois sa date passée (re-notification possible)", () => {
+    const hier = hierIso()
+    marquerAlerteEnvoyee(`u1:gel:${hier}`, { until: hier })
+    expect(alerteDejaEnvoyee(`u1:gel:${hier}`)).toBe(false)
+  })
+
+  it("les entrées expirées sont purgées par nettoyerAlertesEnvoyees", () => {
+    const hier = hierIso()
+    marquerAlerteEnvoyee(`u1:gel:${hier}`, { until: hier })
+    marquerAlerteEnvoyee("u1:canicule:2099-01-01")
+    expect(nombreAlertesMemorisees()).toBe(2)
+    nettoyerAlertesEnvoyees()
+    expect(nombreAlertesMemorisees()).toBe(1)
+  })
+
+  it("une alerte sans date de validité reste mémorisée", () => {
+    marquerAlerteEnvoyee("u1:tache-retard:semis:123")
+    expect(alerteDejaEnvoyee("u1:tache-retard:semis:123")).toBe(true)
+  })
+})

--- a/src/lib/notifications/store.test.ts
+++ b/src/lib/notifications/store.test.ts
@@ -15,6 +15,14 @@ function hierIso(): string {
   return `${hier.getFullYear()}-${m}-${d}`
 }
 
+function demainIso(): string {
+  const demain = new Date()
+  demain.setDate(demain.getDate() + 1)
+  const m = String(demain.getMonth() + 1).padStart(2, "0")
+  const d = String(demain.getDate()).padStart(2, "0")
+  return `${demain.getFullYear()}-${m}-${d}`
+}
+
 describe("store anti-redondance", () => {
   beforeEach(() => {
     resetStorePourTests()
@@ -26,14 +34,16 @@ describe("store anti-redondance", () => {
   })
 
   it("bloque une seconde notification de la même alerte active", () => {
-    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
-    expect(alerteDejaEnvoyee("u1:gel:2026-08-10")).toBe(true)
+    const demain = demainIso()
+    marquerAlerteEnvoyee(`u1:gel:${demain}`, { until: demain })
+    expect(alerteDejaEnvoyee(`u1:gel:${demain}`)).toBe(true)
   })
 
   it("l'anti-redondance est scellée par utilisateur", () => {
-    marquerAlerteEnvoyee("u1:gel:2026-08-10", { until: "2026-08-10" })
+    const demain = demainIso()
+    marquerAlerteEnvoyee(`u1:gel:${demain}`, { until: demain })
     // L'utilisateur 2 dans la même région doit bien être notifié
-    expect(alerteDejaEnvoyee("u2:gel:2026-08-10")).toBe(false)
+    expect(alerteDejaEnvoyee(`u2:gel:${demain}`)).toBe(false)
   })
 
   it("libère l'alerte une fois sa date passée (re-notification possible)", () => {

--- a/src/lib/notifications/store.ts
+++ b/src/lib/notifications/store.ts
@@ -1,0 +1,71 @@
+/**
+ * Anti-redondance des notifications : store EN MÉMOIRE des alertes déjà
+ * envoyées.
+ *
+ * Chaque clé est propre à (utilisateur, alerte) — le sender préfixe par
+ * l'id utilisateur. Les entrées sont purgées dès que leur date de validité
+ * (`until`) est dépassée ou après TTL (7 jours), ce qui permet de
+ * re-notifier une alerte qui revient (ex. gel une autre nuit).
+ *
+ * Volontairement sans dépendance : un store en mémoire évite toute migration
+ * de schéma Prisma et tout risque sur l'instance en production. Au pire un
+ * redémarrage du conteneur peut re-émettre une alerte du jour — acceptable,
+ * et le TTL limite l'accumulation.
+ */
+
+export interface EntreeAlerteEnvoyee {
+  sentAt: number // epoch ms
+  /** Date (YYYY-MM-DD) jusqu'à laquelle l'alerte reste « déjà notifiée ». */
+  until?: string
+}
+
+const TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 jours
+
+const sentAlerts = new Map<string, EntreeAlerteEnvoyee>()
+
+/** Date du jour locale (YYYY-MM-DD) pour les comparaisons d'expiration. */
+function todayKey(): string {
+  const now = new Date()
+  const m = String(now.getMonth() + 1).padStart(2, "0")
+  const d = String(now.getDate()).padStart(2, "0")
+  return `${now.getFullYear()}-${m}-${d}`
+}
+
+/**
+ * L'alerte (clé `key`) a-t-elle déjà été notifiée et est-elle encore active ?
+ */
+export function alerteDejaEnvoyee(key: string): boolean {
+  const entry = sentAlerts.get(key)
+  if (!entry) return false
+  if (entry.until && entry.until < todayKey()) {
+    // L'alerte date d'un jour passé → elle ne bloque plus
+    sentAlerts.delete(key)
+    return false
+  }
+  return true
+}
+
+/** Marque une alerte comme envoyée, avec sa date de validité éventuelle. */
+export function marquerAlerteEnvoyee(key: string, options: { until?: string } = {}): void {
+  sentAlerts.set(key, { sentAt: Date.now(), until: options.until })
+}
+
+/** Purge les entrées expirées ou trop anciennes (appelé à chaque scan). */
+export function nettoyerAlertesEnvoyees(): void {
+  const today = todayKey()
+  for (const [key, entry] of sentAlerts) {
+    const expirée = entry.until !== undefined && entry.until < today
+    const tropVieille = Date.now() - entry.sentAt > TTL_MS
+    if (expirée || tropVieille) sentAlerts.delete(key)
+  }
+}
+
+/** Nombre d'entrées actuellement mémorisées (diagnostic / tests). */
+export function nombreAlertesMemorisees(): number {
+  return sentAlerts.size
+}
+
+/** Vide le store — réservé aux tests. */
+export function resetStorePourTests(): void {
+  sentAlerts.clear()
+}

--- a/src/lib/notifications/templates.test.ts
+++ b/src/lib/notifications/templates.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { alerteUrgenteEmail, resumeQuotidienEmail } from "./templates"
+import type { DestinataireNotification, ResumeQuotidien } from "./types"
+
+const user: DestinataireNotification = { id: "user-1", email: "test@example.com", name: "Alex" }
+
+const resume: ResumeQuotidien = {
+  date: "2026-08-10",
+  taches: [],
+  alertesMeteo: [],
+  stocksBas: [
+    {
+      type: "variete",
+      stockId: 1,
+      nom: "Tomate <ancienne>",
+      unite: "g",
+      quantite: 40,
+      seuilMin: 100,
+      ratio: 0.4,
+      key: "stock-bas:variete:1:100:graines",
+    },
+  ],
+}
+
+describe("templates stocks bas", () => {
+  it("affiche la liste et le lien de réapprovisionnement dans le résumé", () => {
+    const email = resumeQuotidienEmail(user, resume)
+
+    expect(email.html).toContain("Stocks bas")
+    expect(email.html).toContain("Tomate &lt;ancienne&gt;")
+    expect(email.html).toContain("Voir les stocks et réapprovisionner")
+    expect(email.html).toContain("/comptabilite/stocks")
+  })
+
+  it("rend une alerte urgente dédiée pour un stock critique", () => {
+    const email = alerteUrgenteEmail(user, {
+      type: "stock-bas",
+      titre: "stock critique : Foin",
+      message: "Foin : 0 kg (seuil 10 kg, 0%). Réapprovisionnement recommandé.",
+      key: "stock-bas:aliment:2:10",
+    })
+
+    expect(email.subject).toContain("Stock critique")
+    expect(email.html).toContain("Stock critique")
+    expect(email.html).toContain("Gérer les stocks")
+    expect(email.html).toContain("/comptabilite/stocks")
+  })
+})

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -4,7 +4,7 @@
  */
 
 import { APP_URL, escapeHtml } from "@/lib/mail"
-import { formatDateFr } from "./detect"
+import { formatDateFr, formaterTemporaliteAlerte, indicationHoraireAlerte } from "./detect"
 import { labelAlerteMeteoCourt, labelTypeTache, nombreTachesAFaire } from "./resume"
 import type { AlerteMeteoNotification, AlerteUrgente, DestinataireNotification, ResumeQuotidien } from "./types"
 
@@ -154,6 +154,12 @@ export function alerteMeteoEmail(
       headerSubtitle: alerte.niveau === "danger" ? "Niveau danger" : "Niveau attention",
       accent: alerte.niveau === "danger" ? "red" : "amber",
       content: `
+        <p style="margin:0 0 6px;font-size:14px;color:#1e293b;">
+          <strong>Quand :</strong> ${escapeHtml(formaterTemporaliteAlerte(alerte.date))}
+        </p>
+        <p style="margin:0 0 14px;font-size:13px;color:#64748b;font-style:italic;">
+          ${escapeHtml(indicationHoraireAlerte(alerte.type))}
+        </p>
         <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
           ${escapeHtml(alerte.message)}.
         </p>

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -4,7 +4,12 @@
  */
 
 import { APP_URL, escapeHtml } from "@/lib/mail"
-import { formatDateFr, formaterTemporaliteAlerte, indicationHoraireAlerte } from "./detect"
+import {
+  formatDateFr,
+  formaterStockBas,
+  formaterTemporaliteAlerte,
+  indicationHoraireAlerte,
+} from "./detect"
 import { labelAlerteMeteoCourt, labelTypeTache, nombreTachesAFaire } from "./resume"
 import type {
   AlerteMeteoNotification,
@@ -127,6 +132,23 @@ export function resumeQuotidienEmail(
       </table>`)
   }
 
+  if (resume.stocksBas && resume.stocksBas.length > 0) {
+    const lignes = resume.stocksBas
+      .map(
+        (stock) =>
+          `<li style="padding:8px 0;color:#1e293b;font-size:14px;">${escapeHtml(formaterStockBas(stock))}</li>`
+      )
+      .join("")
+    sections.push(`
+      <h2 style="margin:24px 0 12px;font-size:16px;font-weight:600;color:#1e293b;">Stocks bas</h2>
+      <div style="background:#fffbeb;border-radius:10px;padding:12px 16px;border-left:3px solid #f59e0b;">
+        <ul style="margin:0;padding-left:20px;">${lignes}</ul>
+        <a href="${APP_URL}/comptabilite/stocks" style="display:inline-block;margin-top:8px;color:#b45309;font-size:13px;font-weight:600;text-decoration:none;">
+          Voir les stocks et réapprovisionner →
+        </a>
+      </div>`)
+  }
+
   if (resume.alertesMeteo.length > 0) {
     const alertesHtml = resume.alertesMeteo
       .map(
@@ -218,15 +240,24 @@ export function alerteUrgenteEmail(
   // change aussi.
   const estRecolteMure = alerte.type === "recolte-mure"
   const estTacheItpSemaine = alerte.type === "tache-itp-semaine"
+  const estStockBas = alerte.type === "stock-bas"
   const doux = estRecolteMure || estTacheItpSemaine
   return {
     subject: estTacheItpSemaine
       ? `[Gleba] Cette semaine : ${alerte.titre}`
       : estRecolteMure
         ? `[Gleba] Récoltes mûres : ${alerte.titre}`
-        : `[Gleba] Action urgente : ${alerte.titre}`,
+        : estStockBas
+          ? `[Gleba] Stock critique : ${alerte.titre}`
+          : `[Gleba] Action urgente : ${alerte.titre}`,
     html: layoutNotification({
-      headerTitle: estTacheItpSemaine ? "Tâches de la semaine" : estRecolteMure ? "Récoltes mûres" : "Action urgente",
+      headerTitle: estTacheItpSemaine
+        ? "Tâches de la semaine"
+        : estRecolteMure
+          ? "Récoltes mûres"
+          : estStockBas
+            ? "Stock critique"
+            : "Action urgente",
       headerSubtitle: alerte.titre,
       accent: doux ? "amber" : "red",
       content: `
@@ -236,8 +267,8 @@ export function alerteUrgenteEmail(
         <table cellpadding="0" cellspacing="0" style="margin:24px 0 0;">
           <tr>
             <td style="background:linear-gradient(135deg,#059669,#0d9488);border-radius:10px;">
-              <a href="${APP_URL}/calendrier" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
-                Gérer dans Gleba →
+              <a href="${estStockBas ? `${APP_URL}/comptabilite/stocks` : `${APP_URL}/calendrier`}" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                ${estStockBas ? "Gérer les stocks →" : "Gérer dans Gleba →"}
               </a>
             </td>
           </tr>

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -1,0 +1,201 @@
+/**
+ * Templates HTML des emails de notifications métier.
+ * Même style que les autres emails Gleba (layout table, dégradé vert).
+ */
+
+import { APP_URL, escapeHtml } from "@/lib/mail"
+import { formatDateFr } from "./detect"
+import { labelAlerteMeteoCourt, labelTypeTache, nombreTachesAFaire } from "./resume"
+import type { AlerteMeteoNotification, AlerteUrgente, DestinataireNotification, ResumeQuotidien } from "./types"
+
+function layoutNotification(options: {
+  headerTitle: string
+  headerSubtitle?: string
+  accent?: "red" | "amber" | "green"
+  content: string
+}): string {
+  const accent = options.accent ?? "green"
+  const gradient =
+    accent === "red"
+      ? "linear-gradient(135deg,#b91c1c,#ef4444)"
+      : accent === "amber"
+        ? "linear-gradient(135deg,#b45309,#f59e0b)"
+        : "linear-gradient(135deg,#065f46,#0d9488)"
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;padding:40px 20px;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+        <tr>
+          <td style="background:${gradient};padding:28px 40px;text-align:center;">
+            <h1 style="margin:0;font-size:22px;font-weight:300;color:#ffffff;">${escapeHtml(options.headerTitle)}</h1>
+            ${options.headerSubtitle ? `<p style="margin:8px 0 0;font-size:13px;color:#ffffff;opacity:0.9;">${escapeHtml(options.headerSubtitle)}</p>` : ""}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px 40px;">
+            ${options.content}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 40px 28px;border-top:1px solid #f1f5f9;">
+            <p style="margin:0;font-size:12px;color:#94a3b8;text-align:center;">
+              Gleba — Gestion agricole · <a href="${APP_URL}" style="color:#10b981;text-decoration:none;">${APP_URL}</a>
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`
+}
+
+function tacheLigne(tache: ResumeQuotidien["taches"][number]): string {
+  const localisation = tache.plancheName
+    ? ` — ${escapeHtml(tache.plancheName)}${tache.ilot ? ` (ilot ${escapeHtml(tache.ilot)})` : ""}`
+    : ""
+  const variete = tache.varieteNom ? ` <span style="color:#64748b">(${escapeHtml(tache.varieteNom)})</span>` : ""
+  const irrigationInfo =
+    tache.type === "irrigation" && tache.probablementInutile
+      ? `<span style="color:#b45309;font-size:12px;"> — probablement inutile${tache.pluiePrevue != null ? ` (${tache.pluiePrevue} mm prévus)` : ""}</span>`
+      : ""
+  const badge = tache.fait
+    ? `<span style="color:#059669;font-weight:600;">✓ fait</span>`
+    : `<span style="color:#b45309;font-weight:600;">à faire</span>`
+  return `<tr>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:14px;color:#1e293b;">
+      <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${escapeHtml(tache.couleur ?? "#94a3b8")};margin-right:8px;"></span>
+      <strong>${escapeHtml(tache.especeNom)}</strong>${variete}${localisation}
+    </td>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:12px;color:#475569;text-align:right;">${escapeHtml(labelTypeTache(tache.type))}${irrigationInfo}</td>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:13px;text-align:right;">${badge}</td>
+  </tr>`
+}
+
+export function resumeQuotidienEmail(
+  user: DestinataireNotification,
+  resume: ResumeQuotidien
+): { subject: string; html: string } {
+  const dateLabel = formatDateFr(resume.date)
+  const prenom = user.name ? user.name.split(" ")[0] : ""
+
+  const sections: string[] = []
+  if (resume.taches.length > 0) {
+    const lignes = resume.taches.map(tacheLigne).join("")
+    sections.push(`
+      <h2 style="margin:0 0 12px;font-size:16px;font-weight:600;color:#1e293b;">Tâches du jour</h2>
+      <table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e2e8f0;border-radius:10px;overflow:hidden;border-collapse:collapse;">
+        ${lignes}
+      </table>`)
+  } else {
+    sections.push(`
+      <div style="background:#f8fafc;border-radius:10px;padding:16px 20px;border-left:3px solid #0d9488;">
+        <p style="margin:0;font-size:14px;color:#475569;">Rien de prévu aujourd'hui sur le calendrier.</p>
+      </div>`)
+  }
+
+  if (resume.alertesMeteo.length > 0) {
+    const alertesHtml = resume.alertesMeteo
+      .map(
+        (a) => `
+        <div style="background:${a.niveau === "danger" ? "#fef2f2" : "#fffbeb"};border-radius:10px;padding:12px 16px;border-left:3px solid ${a.niveau === "danger" ? "#dc2626" : "#f59e0b"};margin-bottom:10px;">
+          <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">${escapeHtml(a.message)}</p>
+          <p style="margin:6px 0 0;font-size:13px;color:#475569;line-height:1.5;">${escapeHtml(a.details)}</p>
+        </div>`
+      )
+      .join("")
+    sections.push(`
+      <h2 style="margin:24px 0 12px;font-size:16px;font-weight:600;color:#1e293b;">Météo du jour</h2>
+      ${alertesHtml}`)
+  }
+
+  const aFaire = nombreTachesAFaire(resume.taches)
+  const conclusion =
+    aFaire > 0
+      ? `<p style="margin:20px 0 0;font-size:14px;color:#475569;">Bon courage : ${aFaire} action${aFaire > 1 ? "s" : ""} à mener aujourd'hui.</p>`
+      : resume.alertesMeteo.length > 0
+        ? `<p style="margin:20px 0 0;font-size:14px;color:#475569;">Pensez à consulter les alertes météo ci-dessus avant de commencer.</p>`
+        : ""
+
+  return {
+    subject: `[Gleba] Résumé du jour - ${dateLabel}`,
+    html: layoutNotification({
+      headerTitle: `Quoi faire ce matin ?`,
+      headerSubtitle: `Résumé du jour — ${dateLabel}`,
+      content: `
+        ${prenom ? `<p style="margin:0 0 20px;font-size:15px;color:#1e293b;">Bonjour ${escapeHtml(prenom)},</p>` : ""}
+        ${sections.join("")}
+        ${conclusion}
+        <table cellpadding="0" cellspacing="0" style="margin:24px 0 0;">
+          <tr>
+            <td style="background:linear-gradient(135deg,#059669,#0d9488);border-radius:10px;">
+              <a href="${APP_URL}/calendrier" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                Voir le calendrier →
+              </a>
+            </td>
+          </tr>
+        </table>`,
+    }),
+  }
+}
+
+export function alerteMeteoEmail(
+  user: DestinataireNotification,
+  alerte: AlerteMeteoNotification
+): { subject: string; html: string } {
+  const libelle = labelAlerteMeteoCourt(alerte.type)
+  return {
+    subject: `[Gleba] Alerte météo : ${libelle}${alerte.type === "gel" || alerte.type === "canicule" || alerte.type === "vent" || alerte.type === "pluie" ? ` (${formatDateFr(alerte.date)})` : ""}`,
+    html: layoutNotification({
+      headerTitle: `Alerte météo : ${libelle}`,
+      headerSubtitle: alerte.niveau === "danger" ? "Niveau danger" : "Niveau attention",
+      accent: alerte.niveau === "danger" ? "red" : "amber",
+      content: `
+        <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
+          ${escapeHtml(alerte.message)}.
+        </p>
+        <div style="background:${alerte.niveau === "danger" ? "#fef2f2" : "#fffbeb"};border-radius:10px;padding:16px 20px;border-left:3px solid ${alerte.niveau === "danger" ? "#dc2626" : "#f59e0b"};">
+          <p style="margin:0;font-size:14px;color:#1e293b;line-height:1.6;">${escapeHtml(alerte.details)}</p>
+        </div>
+        <table cellpadding="0" cellspacing="0" style="margin:24px 0 0;">
+          <tr>
+            <td style="background:linear-gradient(135deg,#059669,#0d9488);border-radius:10px;">
+              <a href="${APP_URL}/meteo" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                Voir la météo →
+              </a>
+            </td>
+          </tr>
+        </table>`,
+    }),
+  }
+}
+
+export function alerteUrgenteEmail(
+  user: DestinataireNotification,
+  alerte: AlerteUrgente
+): { subject: string; html: string } {
+  return {
+    subject: `[Gleba] Action urgente : ${alerte.titre}`,
+    html: layoutNotification({
+      headerTitle: `Action urgente`,
+      headerSubtitle: alerte.titre,
+      accent: "red",
+      content: `
+        <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
+          ${escapeHtml(alerte.message)}
+        </p>
+        <table cellpadding="0" cellspacing="0" style="margin:24px 0 0;">
+          <tr>
+            <td style="background:linear-gradient(135deg,#059669,#0d9488);border-radius:10px;">
+              <a href="${APP_URL}/calendrier" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                Gérer dans Gleba →
+              </a>
+            </td>
+          </tr>
+        </table>`,
+    }),
+  }
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -183,12 +183,17 @@ export function alerteUrgenteEmail(
   user: DestinataireNotification,
   alerte: AlerteUrgente
 ): { subject: string; html: string } {
+  // Issue #16 : une récolte mûre est un rappel agréable (accent ambre), pas
+  // une action critique (accent rouge) — l'objet change aussi.
+  const estRecolteMure = alerte.type === "recolte-mure"
   return {
-    subject: `[Gleba] Action urgente : ${alerte.titre}`,
+    subject: estRecolteMure
+      ? `[Gleba] Récoltes mûres : ${alerte.titre}`
+      : `[Gleba] Action urgente : ${alerte.titre}`,
     html: layoutNotification({
-      headerTitle: `Action urgente`,
+      headerTitle: estRecolteMure ? "Récoltes mûres" : "Action urgente",
       headerSubtitle: alerte.titre,
-      accent: "red",
+      accent: estRecolteMure ? "amber" : "red",
       content: `
         <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
           ${escapeHtml(alerte.message)}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -6,7 +6,13 @@
 import { APP_URL, escapeHtml } from "@/lib/mail"
 import { formatDateFr, formaterTemporaliteAlerte, indicationHoraireAlerte } from "./detect"
 import { labelAlerteMeteoCourt, labelTypeTache, nombreTachesAFaire } from "./resume"
-import type { AlerteMeteoNotification, AlerteUrgente, DestinataireNotification, ResumeQuotidien } from "./types"
+import type {
+  AlerteMeteoNotification,
+  AlerteUrgente,
+  DestinataireNotification,
+  ResumeQuotidien,
+  TacheItpSemaine,
+} from "./types"
 
 function layoutNotification(options: {
   headerTitle: string
@@ -75,6 +81,21 @@ function tacheLigne(tache: ResumeQuotidien["taches"][number]): string {
   </tr>`
 }
 
+function tacheItpLigne(tache: TacheItpSemaine): string {
+  const localisation = tache.plancheName
+    ? ` — ${escapeHtml(tache.plancheName)}${tache.ilot ? ` (ilot ${escapeHtml(tache.ilot)})` : ""}`
+    : ""
+  const variete = tache.varieteNom ? ` <span style="color:#64748b">(${escapeHtml(tache.varieteNom)})</span>` : ""
+  return `<tr>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:14px;color:#1e293b;">
+      <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${escapeHtml(tache.couleur ?? "#94a3b8")};margin-right:8px;"></span>
+      <strong>${escapeHtml(tache.especeNom)}</strong>${variete}${localisation}
+    </td>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:12px;color:#475569;text-align:right;">${escapeHtml(labelTypeTache(tache.type))}</td>
+    <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;font-size:13px;color:#475569;text-align:right;">${formatDateFr(tache.date)}</td>
+  </tr>`
+}
+
 export function resumeQuotidienEmail(
   user: DestinataireNotification,
   resume: ResumeQuotidien
@@ -95,6 +116,15 @@ export function resumeQuotidienEmail(
       <div style="background:#f8fafc;border-radius:10px;padding:16px 20px;border-left:3px solid #0d9488;">
         <p style="margin:0;font-size:14px;color:#475569;">Rien de prévu aujourd'hui sur le calendrier.</p>
       </div>`)
+  }
+
+  if (resume.tachesItpSemaine && resume.tachesItpSemaine.length > 0) {
+    const lignes = resume.tachesItpSemaine.map(tacheItpLigne).join("")
+    sections.push(`
+      <h2 style="margin:24px 0 12px;font-size:16px;font-weight:600;color:#1e293b;">Cette semaine</h2>
+      <table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e2e8f0;border-radius:10px;overflow:hidden;border-collapse:collapse;">
+        ${lignes}
+      </table>`)
   }
 
   if (resume.alertesMeteo.length > 0) {
@@ -183,17 +213,22 @@ export function alerteUrgenteEmail(
   user: DestinataireNotification,
   alerte: AlerteUrgente
 ): { subject: string; html: string } {
-  // Issue #16 : une récolte mûre est un rappel agréable (accent ambre), pas
-  // une action critique (accent rouge) — l'objet change aussi.
+  // Issue #16 : une récolte mûre ou une tâche ITP de la semaine est un rappel
+  // agréable (accent ambre), pas une action critique (accent rouge) — l'objet
+  // change aussi.
   const estRecolteMure = alerte.type === "recolte-mure"
+  const estTacheItpSemaine = alerte.type === "tache-itp-semaine"
+  const doux = estRecolteMure || estTacheItpSemaine
   return {
-    subject: estRecolteMure
-      ? `[Gleba] Récoltes mûres : ${alerte.titre}`
-      : `[Gleba] Action urgente : ${alerte.titre}`,
+    subject: estTacheItpSemaine
+      ? `[Gleba] Cette semaine : ${alerte.titre}`
+      : estRecolteMure
+        ? `[Gleba] Récoltes mûres : ${alerte.titre}`
+        : `[Gleba] Action urgente : ${alerte.titre}`,
     html: layoutNotification({
-      headerTitle: estRecolteMure ? "Récoltes mûres" : "Action urgente",
+      headerTitle: estTacheItpSemaine ? "Tâches de la semaine" : estRecolteMure ? "Récoltes mûres" : "Action urgente",
       headerSubtitle: alerte.titre,
-      accent: estRecolteMure ? "amber" : "red",
+      accent: doux ? "amber" : "red",
       content: `
         <p style="margin:0 0 16px;font-size:15px;color:#1e293b;line-height:1.6;">
           ${escapeHtml(alerte.message)}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Types partagés du système de notifications métier (alertes par email).
+ * Logique pure : aucun import runtime — sûr pour les tests unitaires.
+ */
+
+/** Types d'alerte météo notifiés par email. */
+export type TypeAlerteMeteo = "gel" | "orage" | "canicule" | "vent" | "pluie"
+
+export interface AlerteMeteoNotification {
+  type: TypeAlerteMeteo
+  /** Date concernée (YYYY-MM-DD). */
+  date: string
+  niveau: "attention" | "danger"
+  message: string
+  details: string
+  /**
+   * Clé stable anti-redondance, propre à l'alerte (ex. `gel:2026-08-10`).
+   * Le sender la préfixe par l'id utilisateur avant d'écrire dans le store.
+   */
+  key: string
+}
+
+/** Type d'une action du calendrier / du résumé du jour. */
+export type TypeTache = "semis" | "plantation" | "recolte" | "irrigation"
+
+export interface TacheJour {
+  id: string | number
+  type: TypeTache
+  especeNom: string
+  varieteNom: string | null
+  plancheName: string | null
+  ilot: string | null
+  date: string // ISO
+  fait: boolean
+  couleur: string | null
+  /** Enrichissement irrigation : pluie prévue le jour J (mm). */
+  pluiePrevue?: number | null
+  /** Enrichissement irrigation : passage probablement inutile (pluie). */
+  probablementInutile?: boolean
+}
+
+export interface ResumeQuotidien {
+  /** Date du résumé (YYYY-MM-DD). */
+  date: string
+  taches: TacheJour[]
+  alertesMeteo: AlerteMeteoNotification[]
+}
+
+/** Types d'alertes urgentes (temps réel). */
+export type TypeAlerteUrgente = "irrigation-inutile" | "association-incompatible" | "tache-retard"
+
+export interface AlerteUrgente {
+  type: TypeAlerteUrgente
+  /** Titre court, repris dans l'objet de l'email (ex. « irrigation planche S4 »). */
+  titre: string
+  message: string
+  /**
+   * Clé stable anti-redondance propre à l'action
+   * (ex. `retard:semis:1234`). Préfixée par l'id utilisateur dans le store.
+   */
+  key: string
+}
+
+/** Destinataire d'une notification (user actif, email valide, pas d'opt-out). */
+export interface DestinataireNotification {
+  id: string
+  email: string
+  name: string | null
+}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -44,6 +44,30 @@ export interface ResumeQuotidien {
   date: string
   taches: TacheJour[]
   alertesMeteo: AlerteMeteoNotification[]
+  /** Tâches ITP de la semaine courante (issue #16), absentes si aucune. */
+  tachesItpSemaine?: TacheItpSemaine[]
+}
+
+/** Type d'opération d'un itinéraire technique (ITP). */
+export type TypeOperationItp = "semis" | "plantation" | "recolte"
+
+/**
+ * Tâche « cette semaine » dérivée du calendrier ITP d'une culture active
+ * (issue #16) : semis, plantation ou récolte dont la fenêtre couvre la
+ * semaine civile courante (lundi → dimanche).
+ */
+export interface TacheItpSemaine {
+  cultureId: number
+  type: TypeOperationItp
+  especeNom: string
+  varieteNom: string | null
+  plancheName: string | null
+  ilot: string | null
+  /** Date cible de l'opération (YYYY-MM-DD, lundi de la semaine de l'op). */
+  date: string
+  /** Numéro de semaine ISO concernée (1-53). */
+  semaine: number
+  couleur: string | null
 }
 
 /** Types d'alertes urgentes (temps réel). */
@@ -52,6 +76,7 @@ export type TypeAlerteUrgente =
   | "association-incompatible"
   | "tache-retard"
   | "recolte-mure" // Issue #16 : maturité calculée (date semis/plantation + durée culture ITP)
+  | "tache-itp-semaine" // Issue #16 : opérations ITP prévues sur la semaine courante
 
 export interface AlerteUrgente {
   type: TypeAlerteUrgente

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -46,6 +46,8 @@ export interface ResumeQuotidien {
   alertesMeteo: AlerteMeteoNotification[]
   /** Tâches ITP de la semaine courante (issue #16), absentes si aucune. */
   tachesItpSemaine?: TacheItpSemaine[]
+  /** Stocks sous seuil minimum (issue #16), absents si aucun. */
+  stocksBas?: StockBas[]
 }
 
 /** Type d'opération d'un itinéraire technique (ITP). */
@@ -77,6 +79,7 @@ export type TypeAlerteUrgente =
   | "tache-retard"
   | "recolte-mure" // Issue #16 : maturité calculée (date semis/plantation + durée culture ITP)
   | "tache-itp-semaine" // Issue #16 : opérations ITP prévues sur la semaine courante
+  | "stock-bas" // Issue #16 : stock passé sous le seuil minimum
 
 export interface AlerteUrgente {
   type: TypeAlerteUrgente
@@ -87,6 +90,30 @@ export interface AlerteUrgente {
    * Clé stable anti-redondance propre à l'action
    * (ex. `retard:semis:1234`). Préfixée par l'id utilisateur dans le store.
    */
+  key: string
+}
+
+/** Type de stock concerné par une alerte stock bas. */
+export type TypeStockBas = "variete" | "fertilisant" | "aliment"
+
+/** Stock détecté sous son seuil minimum. */
+export interface StockBas {
+  type: TypeStockBas
+  /** ID de l'entrée de stock (UserStockVariete.id, UserStockFertilisant.id, UserStockAliment.id). */
+  stockId: number
+  /** Nom de l'élément (variété, fertilisant, aliment). */
+  nom: string
+  /** Unité du stock (g, plants, kg, L). */
+  unite: string
+  /** Quantité actuelle en stock. */
+  quantite: number
+  /** Seuil minimum défini. */
+  seuilMin: number
+  /** Pourcentage du seuil atteint (ex. 0.5 = 50% du seuil). */
+  ratio: number
+  /** Localisation optionnelle (planche, ilot, etc.). */
+  localisation?: string
+  /** Clé stable anti-redondance (ex. `stock-bas:variete:123:50`). */
   key: string
 }
 

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -47,7 +47,11 @@ export interface ResumeQuotidien {
 }
 
 /** Types d'alertes urgentes (temps réel). */
-export type TypeAlerteUrgente = "irrigation-inutile" | "association-incompatible" | "tache-retard"
+export type TypeAlerteUrgente =
+  | "irrigation-inutile"
+  | "association-incompatible"
+  | "tache-retard"
+  | "recolte-mure" // Issue #16 : maturité calculée (date semis/plantation + durée culture ITP)
 
 export interface AlerteUrgente {
   type: TypeAlerteUrgente

--- a/src/lib/plan-croissance.ts
+++ b/src/lib/plan-croissance.ts
@@ -13,7 +13,7 @@ const JOUR_MS = 24 * 3600 * 1000
 const AN_MS = 365.25 * JOUR_MS
 
 /** Durée de croissance par défaut quand l'ITP ne la donne pas (jours). */
-const DUREE_CULTURE_DEFAUT = 90
+export const DUREE_CULTURE_DEFAUT = 90
 /** Durée de récolte par défaut après maturité (semaines). */
 const DUREE_RECOLTE_DEFAUT_SEMAINES = 6
 /** Taille relative minimale d'un jeune plant (reste visible dès la plantation). */


### PR DESCRIPTION
Ajoute la détection et l'alerte des stocks passés sous leur seuil minimum (issue #16).

**Changements :**
- **Schema Prisma** : champs  /  sur ,  sur  + migration
- **Types** : , , intégration dans  et 
- **Détection pure** () : 3 détecteurs (varietes/fertilisants/aliments), fusion triée par criticité (ratio), formatage
- **Queries** :  pour récupérer les stocks avec seuils depuis la DB
- **Templates** : section « Stocks sous seuil » dans le résumé quotidien + template d'alerte urgente stock critique
- **Sender/Scheduler** : injection des stocks bas dans le résumé + émission d'alertes urgentes
- **Tests** :  (cas nominaux, seuils nuls, ratio) + 

**Poussé sur** :  (commit )

À merger après review.